### PR TITLE
feat: add current-duel equity display

### DIFF
--- a/app/components/PowerupGuideModal.tsx
+++ b/app/components/PowerupGuideModal.tsx
@@ -62,8 +62,7 @@ const PowerupGuideModal: React.FC<PowerupGuideModalProps> = ({
 
   return (
     <div
-      role="dialog"
-      aria-modal="true"
+      role="presentation"
       style={{
         position: 'fixed',
         top: 0,
@@ -77,17 +76,34 @@ const PowerupGuideModal: React.FC<PowerupGuideModalProps> = ({
         justifyContent: 'center',
         zIndex: 1000
       }}
-      onClick={onClose}
     >
+      <button
+        type="button"
+        aria-label="Close power-up guide"
+        onClick={onClose}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          padding: 0,
+          border: 0,
+          background: 'transparent',
+          cursor: 'default'
+        }}
+      />
       <div
+        role="dialog"
+        aria-modal="true"
         className="rpg-panel"
         style={{
           padding: '30px',
           width: 'min(600px, 90%)',
           background: 'rgba(15, 12, 41, 0.95)',
-          border: '2px solid var(--color-secondary)'
+          border: '2px solid var(--color-secondary)',
+          position: 'relative',
+          zIndex: 1
         }}
-        onClick={(e) => e.stopPropagation()}
       >
         <h2
           className="text-glow"

--- a/app/components/RoundStatus.tsx
+++ b/app/components/RoundStatus.tsx
@@ -182,7 +182,21 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
       return availableCount > 1;
     };
 
-    const PowerUpButton = ({ type, count, enabled, icon, label, color }: any) =>
+    const PowerUpButton = ({
+      type,
+      count,
+      enabled,
+      icon,
+      label,
+      color
+    }: {
+      type: ChanceType;
+      count: number;
+      enabled: boolean;
+      icon: string;
+      label: string;
+      color: string;
+    }) =>
       count > 0 && (
         <div style={{ position: 'relative', margin: '0 8px', width: '100px' }}>
           <button

--- a/app/components/ShareButtons.tsx
+++ b/app/components/ShareButtons.tsx
@@ -16,18 +16,27 @@ export default function ShareButtons(props: ShareButtonsProps) {
   const shareTitle = "Thor's 3Key — Chaotic team card showdown";
   const shareText =
     "Fast, silly, team-based card chaos. Load players from Google Sheets, slam power-ups, and trash talk your way to victory.";
+  const nativeNavigator = useMemo(
+    () =>
+    typeof navigator !== 'undefined'
+      ? (navigator as Navigator & {
+          share?: (data: ShareData) => Promise<void>;
+        })
+      : null,
+    []
+  );
 
   const canNativeShare =
-    typeof window !== 'undefined' && typeof navigator !== 'undefined' &&
-    typeof (navigator as any).share === 'function';
+    typeof window !== 'undefined' &&
+    typeof nativeNavigator?.share === 'function';
 
   const onNativeShare = useCallback(async () => {
-    await (navigator as any).share({
+    await nativeNavigator?.share?.({
       title: shareTitle,
       text: shareText,
       url: shareUrl
     }).catch(() => {});
-  }, [shareTitle, shareText, shareUrl]);
+  }, [nativeNavigator, shareTitle, shareText, shareUrl]);
 
   const onCopy = useCallback(async () => {
     await navigator.clipboard.writeText(shareUrl)
@@ -90,5 +99,3 @@ const buttonStyle: React.CSSProperties = {
   cursor: 'pointer',
   textDecoration: 'none'
 };
-
-

--- a/app/contexts/LanguageContext.tsx
+++ b/app/contexts/LanguageContext.tsx
@@ -9,12 +9,12 @@ import en from '../locales/en';
 import vi from '../locales/vi';
 
 type Language = 'en' | 'vi';
-type Translations = typeof en;
+type TranslationNode = string | { [key: string]: TranslationNode };
 
 interface LanguageContextType {
   language: Language;
   setLanguage: (lang: Language) => void;
-  t: (path: string, options?: any) => string;
+  t: (path: string, options?: Record<string, unknown>) => string;
 }
 
 const LanguageContext = createContext<LanguageContextType | undefined>(
@@ -37,12 +37,12 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
     localStorage.setItem('app-language', lang);
   };
 
-  const t = (path: string, options?: any): string => {
+  const t = (path: string, options?: Record<string, unknown>): string => {
     const keys = path.split('.');
-    let current: any = language === 'en' ? en : vi;
+    let current: TranslationNode = language === 'en' ? en : vi;
 
     for (const key of keys) {
-      if (current[key] === undefined) {
+      if (typeof current === 'string' || current[key] === undefined) {
         console.warn(
           `Translation missing for key: ${path} in language: ${language}`
         );
@@ -54,7 +54,10 @@ export const LanguageProvider = ({ children }: { children: ReactNode }) => {
     if (options) {
       Object.keys(options).forEach((key) => {
         if (options[key]) {
-          current = current.replace(`{{${key}}}`, options[key]);
+          current =
+            typeof current === 'string'
+              ? current.replace(`{{${key}}}`, String(options[key]))
+              : current;
         }
       });
     }

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -81,8 +81,35 @@ const GameArenaScreen = ({
             {player2EquityName}: {duelEquity.player2.winRate}%
           </span>
         </div>
-      ): <div className='placeholder' style={{height: '54px'}}>
-        </div>}
+      ) : (
+        <div
+          className="rpg-panel"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '16px',
+            padding: '10px 16px',
+            margin: '0 auto 12px',
+            background: 'var(--color-panel-bg)',
+            border: '1px solid var(--color-accent)',
+            color: '#fff',
+            fontFamily: 'var(--font-body)',
+            fontSize: '16px',
+            position: 'relative',
+            zIndex: 10,
+            visibility: 'hidden'
+          }}
+        >
+          <span style={{ color: 'var(--color-primary)' }}>
+            {player1EquityName}: 0%
+          </span>
+          <span style={{ color: 'var(--color-accent)' }}>|</span>
+          <span style={{ color: 'var(--color-secondary)' }}>
+            {player2EquityName}: 0%
+          </span>
+        </div>
+      )}
       <div
         style={{
           display: 'flex',

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -54,6 +54,35 @@ const GameArenaScreen = ({
 
   return (
     <>
+      {duelEquity ? (
+        <div
+          className="rpg-panel"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '16px',
+            padding: '10px 16px',
+            margin: '0 auto 12px',
+            background: 'var(--color-panel-bg)',
+            border: '1px solid var(--color-accent)',
+            color: '#fff',
+            fontFamily: 'var(--font-body)',
+            fontSize: '16px',
+            position: 'relative',
+            zIndex: 10
+          }}
+        >
+          <span style={{ color: 'var(--color-primary)' }}>
+            {player1EquityName}: {duelEquity.player1.winRate}%
+          </span>
+          <span style={{ color: 'var(--color-accent)' }}>|</span>
+          <span style={{ color: 'var(--color-secondary)' }}>
+            {player2EquityName}: {duelEquity.player2.winRate}%
+          </span>
+        </div>
+      ): <div className='placeholder' style={{height: '54px'}}>
+        </div>}
       <div
         style={{
           display: 'flex',
@@ -292,34 +321,6 @@ const GameArenaScreen = ({
         </div>
       </div>
 
-      {duelEquity && (
-        <div
-          className="rpg-panel"
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: '16px',
-            padding: '10px 16px',
-            margin: '0 auto 12px',
-            background: 'var(--color-panel-bg)',
-            border: '1px solid var(--color-accent)',
-            color: '#fff',
-            fontFamily: 'var(--font-body)',
-            fontSize: '16px',
-            position: 'relative',
-            zIndex: 10
-          }}
-        >
-          <span style={{ color: 'var(--color-primary)' }}>
-            {player1EquityName}: {duelEquity.player1.winRate}%
-          </span>
-          <span style={{ color: 'var(--color-accent)' }}>|</span>
-          <span style={{ color: 'var(--color-secondary)' }}>
-            {player2EquityName}: {duelEquity.player2.winRate}%
-          </span>
-        </div>
-      )}
 
       <RoundStatus
         duelResult={duelResult}

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -8,6 +8,7 @@ import { ChanceType, TeamData } from '~/models/TeamData';
 import { CARDS_COVER } from '~/utils/gameUtil';
 import { useLanguage } from '~/contexts/LanguageContext';
 import { Side, TeamName } from '../types/gameTypes';
+import { DuelEquity } from '~/features/game/engine/equityEngine';
 
 type GameArenaScreenProps = {
   duelResult: string;
@@ -30,6 +31,7 @@ type GameArenaScreenProps = {
     teamName: TeamName,
     chanceType: ChanceType
   ) => void;
+  duelEquity: DuelEquity | null;
 };
 
 const GameArenaScreen = ({
@@ -43,9 +45,12 @@ const GameArenaScreen = ({
   isPlayerCardDrawerDisabled,
   renderTheCards,
   nextRound,
-  onChanceClick
+  onChanceClick,
+  duelEquity
 }: GameArenaScreenProps) => {
   const { t } = useLanguage();
+  const player1EquityName = duelData.player1Name;
+  const player2EquityName = duelData.player2Name || duelData.currentPlayerName;
 
   return (
     <>
@@ -286,6 +291,35 @@ const GameArenaScreen = ({
           </div>
         </div>
       </div>
+
+      {duelEquity && (
+        <div
+          className="rpg-panel"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '16px',
+            padding: '10px 16px',
+            margin: '0 auto 12px',
+            background: 'var(--color-panel-bg)',
+            border: '1px solid var(--color-accent)',
+            color: '#fff',
+            fontFamily: 'var(--font-body)',
+            fontSize: '16px',
+            position: 'relative',
+            zIndex: 10
+          }}
+        >
+          <span style={{ color: 'var(--color-primary)' }}>
+            {player1EquityName}: {duelEquity.player1.winRate}%
+          </span>
+          <span style={{ color: 'var(--color-accent)' }}>|</span>
+          <span style={{ color: 'var(--color-secondary)' }}>
+            {player2EquityName}: {duelEquity.player2.winRate}%
+          </span>
+        </div>
+      )}
 
       <RoundStatus
         duelResult={duelResult}

--- a/app/features/game/engine/equityEngine.test.ts
+++ b/app/features/game/engine/equityEngine.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { calculateDuelEquity } from '~/features/game/engine/equityEngine';
+import { createInitialDuelData } from '~/features/game/state/initialState';
+import DuelData from '~/models/DuelData';
+
+const withPlayer1Selection = (
+  updates: Partial<DuelData> = {}
+): DuelData => ({
+  ...createInitialDuelData(),
+  currentPlayerName: 'Bob',
+  duelIndex: 1,
+  player1Name: 'Alice',
+  player1SideSelected: 'top-left',
+  topLeftRevealed: true,
+  topLeftCards: [
+    { value: 9, suit: '♦' },
+    { value: 9, suit: '♥' },
+    { value: 9, suit: '♠' }
+  ],
+  topLeftPlayerData: {
+    name: 'Alice',
+    team: 'team1',
+    sum: 7,
+    cards: [
+      { value: 9, suit: '♦' },
+      { value: 9, suit: '♥' },
+      { value: 9, suit: '♠' }
+    ]
+  },
+  ...updates
+});
+
+describe('calculateDuelEquity', () => {
+  it('returns null before player 1 selects a side', () => {
+    expect(calculateDuelEquity(createInitialDuelData())).toBeNull();
+  });
+
+  it('returns public-information equity after player 1 selects only', () => {
+    const equity = calculateDuelEquity(withPlayer1Selection());
+
+    expect(equity).not.toBeNull();
+    expect(equity?.player1.winRate).toBeGreaterThan(0);
+    expect(equity?.player1.winRate).toBeLessThan(100);
+    expect(equity?.player1.equity).toBe(equity?.player1.winRate);
+    expect(equity?.player2.winRate).toBe(100 - (equity?.player1.winRate ?? 0));
+    expect(equity?.player2.equity).toBe(equity?.player2.winRate);
+  });
+
+  it('does not change pre-reveal equity when hidden generated groups change', () => {
+    const firstHiddenLayout = withPlayer1Selection({
+      bottomLeftCards: [
+        { value: 9, suit: '♦' },
+        { value: 9, suit: '♥' },
+        { value: 9, suit: '♠' }
+      ],
+      topRightCards: [
+        { value: 8, suit: '♦' },
+        { value: 8, suit: '♥' },
+        { value: 8, suit: '♠' }
+      ]
+    });
+    const secondHiddenLayout = withPlayer1Selection({
+      bottomLeftCards: [
+        { value: 1, suit: '♦' },
+        { value: 1, suit: '♥' },
+        { value: 1, suit: '♠' }
+      ],
+      topRightCards: [
+        { value: 2, suit: '♦' },
+        { value: 2, suit: '♥' },
+        { value: 2, suit: '♠' }
+      ]
+    });
+
+    expect(calculateDuelEquity(firstHiddenLayout)).toEqual(
+      calculateDuelEquity(secondHiddenLayout)
+    );
+  });
+
+  it('returns exact equity after player 2 selects a losing hand', () => {
+    const equity = calculateDuelEquity(
+      withPlayer1Selection({
+        duelIndex: 2,
+        player2Name: 'Bob',
+        player2SideSelected: 'bottom-right',
+        bottomRightRevealed: true,
+        bottomRightCards: [
+          { value: 4, suit: '♣' },
+          { value: 5, suit: '♣' },
+          { value: 1, suit: '♣' }
+        ],
+        bottomRightPlayerData: {
+          name: 'Bob',
+          team: 'team2',
+          sum: 10,
+          cards: [
+            { value: 4, suit: '♣' },
+            { value: 5, suit: '♣' },
+            { value: 1, suit: '♣' }
+          ]
+        }
+      })
+    );
+
+    expect(equity).toEqual({
+      player1: { winRate: 0, equity: 0 },
+      player2: { winRate: 100, equity: 100 }
+    });
+  });
+
+  it('uses tie-break rules for exact post-selection equity', () => {
+    const equity = calculateDuelEquity(
+      withPlayer1Selection({
+        duelIndex: 2,
+        topLeftCards: [
+          { value: 4, suit: '♣' },
+          { value: 3, suit: '♣' },
+          { value: 2, suit: '♣' }
+        ],
+        topLeftPlayerData: {
+          name: 'Alice',
+          team: 'team1',
+          sum: 9,
+          cards: [
+            { value: 4, suit: '♣' },
+            { value: 3, suit: '♣' },
+            { value: 2, suit: '♣' }
+          ]
+        },
+        player2Name: 'Bob',
+        player2SideSelected: 'bottom-right',
+        bottomRightRevealed: true,
+        bottomRightCards: [
+          { value: 4, suit: '♦' },
+          { value: 3, suit: '♣' },
+          { value: 2, suit: '♣' }
+        ],
+        bottomRightPlayerData: {
+          name: 'Bob',
+          team: 'team2',
+          sum: 9,
+          cards: [
+            { value: 4, suit: '♦' },
+            { value: 3, suit: '♣' },
+            { value: 2, suit: '♣' }
+          ]
+        }
+      })
+    );
+
+    expect(equity).toEqual({
+      player1: { winRate: 0, equity: 0 },
+      player2: { winRate: 100, equity: 100 }
+    });
+  });
+});

--- a/app/features/game/engine/equityEngine.ts
+++ b/app/features/game/engine/equityEngine.ts
@@ -1,0 +1,102 @@
+import DuelData from '~/models/DuelData';
+import Card from '~/models/Card';
+import { Side } from '~/features/game/types/gameTypes';
+import { compareHands, createDeck } from '~/utils/gameUtil';
+import { getPlayerDataBySide } from './duelEngine';
+
+export type DuelEquitySide = {
+  winRate: number;
+  equity: number;
+};
+
+export type DuelEquity = {
+  player1: DuelEquitySide;
+  player2: DuelEquitySide;
+};
+
+const hasCompleteHand = (cards: Card[]): boolean => {
+  return cards.length === 3 && cards.every((card) => card.value > 0 && card.suit);
+};
+
+const isSameCard = (left: Card, right: Card): boolean => {
+  return left.value === right.value && left.suit === right.suit;
+};
+
+const createEquity = (player1WinRate: number): DuelEquity => {
+  const player2WinRate = 100 - player1WinRate;
+  return {
+    player1: {
+      winRate: player1WinRate,
+      equity: player1WinRate
+    },
+    player2: {
+      winRate: player2WinRate,
+      equity: player2WinRate
+    }
+  };
+};
+
+const createThreeCardCombinations = (cards: Card[]): Card[][] => {
+  const combinations: Card[][] = [];
+
+  for (let first = 0; first < cards.length - 2; first++) {
+    for (let second = first + 1; second < cards.length - 1; second++) {
+      for (let third = second + 1; third < cards.length; third++) {
+        combinations.push([cards[first], cards[second], cards[third]]);
+      }
+    }
+  }
+
+  return combinations;
+};
+
+const getSelectedCards = (
+  duelData: DuelData,
+  selectedSide?: Side
+): Card[] | null => {
+  if (!selectedSide) {
+    return null;
+  }
+
+  const cards = getPlayerDataBySide(duelData, selectedSide).cards;
+  return hasCompleteHand(cards) ? cards : null;
+};
+
+const calculatePlayer1PublicWinRate = (player1Cards: Card[]): number => {
+  const possibleOpponentCards = createDeck().filter(
+    (card) => !player1Cards.some((selected) => isSameCard(card, selected))
+  );
+  const possibleOpponentHands =
+    createThreeCardCombinations(possibleOpponentCards);
+  const player1Wins = possibleOpponentHands.filter(
+    (opponentCards) => compareHands(player1Cards, opponentCards) === 'player1'
+  ).length;
+
+  return Math.round((player1Wins / possibleOpponentHands.length) * 100);
+};
+
+export const calculateDuelEquity = (
+  duelData: DuelData
+): DuelEquity | null => {
+  const player1Cards = getSelectedCards(
+    duelData,
+    duelData.player1SideSelected
+  );
+
+  if (!player1Cards) {
+    return null;
+  }
+
+  const player2Cards = getSelectedCards(
+    duelData,
+    duelData.player2SideSelected
+  );
+
+  if (player2Cards) {
+    return createEquity(
+      compareHands(player1Cards, player2Cards) === 'player1' ? 100 : 0
+    );
+  }
+
+  return createEquity(calculatePlayer1PublicWinRate(player1Cards));
+};

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -233,16 +233,16 @@ const CardGame = () => {
       setIsFirstTurn(roundNumber == 0);
 
       const deck = shuffleDeck([...DECKS]);
+      const firstRandomizedTeam = Math.random() >= 0.5 ? inputTeam1 : inputTeam2;
 
       setDuelData((prev) => ({
         ...prev,
         duelIndex: 0,
         currentPlayerName:
           roundNumber === 0
-            ? Math.random() >= 0.5
-              ? inputTeam1[0]
-              : inputTeam2[0]
+            ? firstRandomizedTeam[0]
             : prev.currentPlayerName,
+
         player1Name: '',
         player1Team: undefined,
         player2Name: '',
@@ -372,42 +372,42 @@ const CardGame = () => {
           topLeftPlayerData:
             (newData.topLeftPlayerData.cards.length == 0 ||
               !newData.topLeftRevealed) &&
-            shouldRevealAllCards
+              shouldRevealAllCards
               ? {
-                  ...newData.topLeftPlayerData,
-                  cards: newData.topLeftCards,
-                  sum: calculateSum(newData.topLeftCards)
-                }
+                ...newData.topLeftPlayerData,
+                cards: newData.topLeftCards,
+                sum: calculateSum(newData.topLeftCards)
+              }
               : newData.topLeftPlayerData,
           bottomLeftPlayerData:
             (newData.bottomLeftPlayerData.cards.length == 0 ||
               !newData.bottomLeftRevealed) &&
-            shouldRevealAllCards
+              shouldRevealAllCards
               ? {
-                  ...newData.bottomLeftPlayerData,
-                  cards: newData.bottomLeftCards,
-                  sum: calculateSum(newData.bottomLeftCards)
-                }
+                ...newData.bottomLeftPlayerData,
+                cards: newData.bottomLeftCards,
+                sum: calculateSum(newData.bottomLeftCards)
+              }
               : newData.bottomLeftPlayerData,
           topRightPlayerData:
             (newData.topRightPlayerData.cards.length == 0 ||
               !newData.topRightRevealed) &&
-            shouldRevealAllCards
+              shouldRevealAllCards
               ? {
-                  ...newData.topRightPlayerData,
-                  cards: newData.topRightCards,
-                  sum: calculateSum(newData.topRightCards)
-                }
+                ...newData.topRightPlayerData,
+                cards: newData.topRightCards,
+                sum: calculateSum(newData.topRightCards)
+              }
               : newData.topRightPlayerData,
           bottomRightPlayerData:
             (newData.bottomRightPlayerData.cards.length == 0 ||
               !newData.bottomRightRevealed) &&
-            shouldRevealAllCards
+              shouldRevealAllCards
               ? {
-                  ...newData.bottomRightPlayerData,
-                  cards: newData.bottomRightCards,
-                  sum: calculateSum(newData.bottomRightCards)
-                }
+                ...newData.bottomRightPlayerData,
+                cards: newData.bottomRightCards,
+                sum: calculateSum(newData.bottomRightCards)
+              }
               : newData.bottomRightPlayerData
         };
 
@@ -1033,11 +1033,11 @@ const CardGame = () => {
         onKeyDown={
           onCardClick && !disabled
             ? (e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  onCardClick();
-                }
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onCardClick();
               }
+            }
             : undefined
         }
       />
@@ -1495,7 +1495,7 @@ const CardGame = () => {
                                   team1Alloc.revealTwo +
                                   team1Alloc.lifeShield +
                                   team1Alloc.removeWorst !==
-                                team1Data.totalPowerUps
+                                  team1Data.totalPowerUps
                                   ? 'red'
                                   : undefined
                             }}
@@ -1670,7 +1670,7 @@ const CardGame = () => {
                                     team1Alloc.revealTwo +
                                     team1Alloc.lifeShield +
                                     team1Alloc.removeWorst !==
-                                  team1Data.totalPowerUps
+                                    team1Data.totalPowerUps
                                     ? 'red'
                                     : undefined
                               }}
@@ -1844,7 +1844,7 @@ const CardGame = () => {
                                     team2Alloc.revealTwo +
                                     team2Alloc.lifeShield +
                                     team2Alloc.removeWorst !==
-                                  team2Data.totalPowerUps
+                                    team2Data.totalPowerUps
                                     ? 'red'
                                     : undefined
                               }}

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -1,5 +1,5 @@
 import { useOutletContext } from '@remix-run/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLanguage } from '~/contexts/LanguageContext';
 import { useTheme } from '~/contexts/ThemeContext';
 import GameArenaScreen from '~/features/game/components/GameArenaScreen';
@@ -2101,7 +2101,7 @@ const CardGame = () => {
     );
   }
 
-  const duelEquity = calculateDuelEquity(duelData);
+  const duelEquity = useMemo(() => calculateDuelEquity(duelData), [duelData]);
 
   return (
     <div style={{ textAlign: 'center', padding: '0 20px', height: '100%' }}>

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -11,6 +11,7 @@ import {
   getCardsBySide,
   getPlayerDataBySide
 } from '~/features/game/engine/duelEngine';
+import { calculateDuelEquity } from '~/features/game/engine/equityEngine';
 import {
   generateRandomAllocation,
   isStartGameDisabledByAllocation
@@ -2100,6 +2101,8 @@ const CardGame = () => {
     );
   }
 
+  const duelEquity = calculateDuelEquity(duelData);
+
   return (
     <div style={{ textAlign: 'center', padding: '0 20px', height: '100%' }}>
       {renderGameInput()}
@@ -2121,6 +2124,7 @@ const CardGame = () => {
           renderTheCards={renderTheCards}
           nextRound={nextRound}
           onChanceClick={handleChanceClick}
+          duelEquity={duelEquity}
         />
       )}
 

--- a/app/utils/gameUtil.test.ts
+++ b/app/utils/gameUtil.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { compareHands } from '~/utils/gameUtil';
+
+describe('compareHands', () => {
+  it('chooses the hand with the higher calculated sum', () => {
+    expect(
+      compareHands(
+        [
+          { value: 4, suit: '♣' },
+          { value: 2, suit: '♣' },
+          { value: 1, suit: '♣' }
+        ],
+        [
+          { value: 3, suit: '♦' },
+          { value: 2, suit: '♦' },
+          { value: 1, suit: '♦' }
+        ]
+      )
+    ).toBe('player1');
+  });
+
+  it('uses suit rank when calculated sums are tied', () => {
+    expect(
+      compareHands(
+        [
+          { value: 4, suit: '♣' },
+          { value: 3, suit: '♣' },
+          { value: 2, suit: '♣' }
+        ],
+        [
+          { value: 4, suit: '♦' },
+          { value: 3, suit: '♣' },
+          { value: 2, suit: '♣' }
+        ]
+      )
+    ).toBe('player2');
+  });
+
+  it('treats ace as the highest value when highest suits are tied', () => {
+    expect(
+      compareHands(
+        [
+          { value: 1, suit: '♠' },
+          { value: 5, suit: '♣' },
+          { value: 3, suit: '♣' }
+        ],
+        [
+          { value: 9, suit: '♠' },
+          { value: 5, suit: '♣' },
+          { value: 3, suit: '♣' }
+        ]
+      )
+    ).toBe('player1');
+  });
+
+  it('uses highest card value when sums and highest suits are tied', () => {
+    expect(
+      compareHands(
+        [
+          { value: 8, suit: '♥' },
+          { value: 7, suit: '♣' },
+          { value: 4, suit: '♣' }
+        ],
+        [
+          { value: 9, suit: '♥' },
+          { value: 6, suit: '♣' },
+          { value: 4, suit: '♣' }
+        ]
+      )
+    ).toBe('player2');
+  });
+});

--- a/app/utils/gameUtil.test.ts
+++ b/app/utils/gameUtil.test.ts
@@ -41,13 +41,13 @@ describe('compareHands', () => {
       compareHands(
         [
           { value: 1, suit: '♠' },
-          { value: 5, suit: '♣' },
+          { value: 8, suit: '♣' },
           { value: 3, suit: '♣' }
         ],
         [
           { value: 9, suit: '♠' },
-          { value: 5, suit: '♣' },
-          { value: 3, suit: '♣' }
+          { value: 1, suit: '♣' },
+          { value: 2, suit: '♣' }
         ]
       )
     ).toBe('player1');

--- a/app/utils/gameUtil.ts
+++ b/app/utils/gameUtil.ts
@@ -244,7 +244,7 @@ export const determineWinner = (
   p2Cards: Card[],
   p1Name: string,
   p2Name: string,
-  t: (key: string, options?: Record<string, any>) => string
+  t: (key: string, options?: Record<string, unknown>) => string
 ): { winner: string; isPlayer1Winner: boolean } => {
   let winner: string;
   const isPlayer1Winner = compareHands(p1Cards, p2Cards) === 'player1';

--- a/app/utils/gameUtil.ts
+++ b/app/utils/gameUtil.ts
@@ -194,6 +194,39 @@ export const getCardHighestSuitAndValue = (cards: Card[]): Card => {
   });
 };
 
+export type HandWinner = 'player1' | 'player2';
+
+const getTieBreakCardValue = (card: Card): number => {
+  return card.value === 1 ? 14 : card.value;
+};
+
+export const compareHands = (
+  player1Cards: Card[],
+  player2Cards: Card[]
+): HandWinner => {
+  const player1Sum = calculateSum(player1Cards);
+  const player2Sum = calculateSum(player2Cards);
+
+  if (player1Sum !== player2Sum) {
+    return player1Sum > player2Sum ? 'player1' : 'player2';
+  }
+
+  const player1HighestCard = getCardHighestSuitAndValue(player1Cards);
+  const player2HighestCard = getCardHighestSuitAndValue(player2Cards);
+
+  if (suitRank[player1HighestCard.suit] !== suitRank[player2HighestCard.suit]) {
+    return suitRank[player1HighestCard.suit] >
+      suitRank[player2HighestCard.suit]
+      ? 'player1'
+      : 'player2';
+  }
+
+  return getTieBreakCardValue(player1HighestCard) >
+    getTieBreakCardValue(player2HighestCard)
+    ? 'player1'
+    : 'player2';
+};
+
 /**
  * Determines the winner between two players and returns game result
  * @param p1Sum - Player 1's card sum
@@ -214,28 +247,22 @@ export const determineWinner = (
   t: (key: string, options?: Record<string, any>) => string
 ): { winner: string; isPlayer1Winner: boolean } => {
   let winner: string;
-  let isPlayer1Winner: boolean;
+  const isPlayer1Winner = compareHands(p1Cards, p2Cards) === 'player1';
+
   if (p1Sum === p2Sum) {
     const p1HighestCard = getCardHighestSuitAndValue(p1Cards);
     const p2HighestCard = getCardHighestSuitAndValue(p2Cards);
 
     if (suitRank[p1HighestCard.suit] === suitRank[p2HighestCard.suit]) {
-      isPlayer1Winner =
-        p1HighestCard.value === 1 ||
-        (p2HighestCard.value !== 1 &&
-          p1HighestCard.value > p2HighestCard.value);
       winner = t('game.winsByHighestCard', {
         name: isPlayer1Winner ? p1Name : p2Name
       });
     } else {
-      isPlayer1Winner =
-        suitRank[p1HighestCard.suit] > suitRank[p2HighestCard.suit];
       winner = t('game.winsBySuit', {
         name: isPlayer1Winner ? p1Name : p2Name
       });
     }
   } else {
-    isPlayer1Winner = p1Sum > p2Sum;
     winner = t('game.wins', {
       winner: isPlayer1Winner ? p1Name : p2Name,
       loser: isPlayer1Winner ? p2Name : p1Name

--- a/docs/superpowers/plans/2026-05-16-duel-equity.md
+++ b/docs/superpowers/plans/2026-05-16-duel-equity.md
@@ -1,0 +1,70 @@
+# Duel Equity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a poker-style current-duel equity display that preserves suspense by using public information before player 2 chooses.
+
+**Architecture:** Add a shared pure hand comparator, a deterministic equity engine, and a compact UI display in the existing game arena. The engine returns `null` before player 1 chooses, public-information percentages after player 1 chooses, and exact `100 / 0` after player 2 chooses.
+
+**Tech Stack:** Remix v2, React 18, TypeScript, Vitest.
+
+---
+
+### Task 1: Test Tooling
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+
+- [ ] Add `vitest` as a dev dependency.
+- [ ] Add `npm run test`.
+- [ ] Configure `~/` alias in `vitest.config.ts`.
+- [ ] Run `npm run typecheck`.
+- [ ] Commit with `test: add vitest setup`.
+
+### Task 2: Shared Hand Comparison
+
+**Files:**
+- Modify: `app/utils/gameUtil.ts`
+- Create: `app/utils/gameUtil.test.ts`
+
+- [ ] Write tests for normal sum comparison, suit tie-break, ace-high tie-break, and equal-suit value tie-break.
+- [ ] Run the focused test and confirm it fails before implementation.
+- [ ] Add `compareHands(player1Cards, player2Cards)`.
+- [ ] Refactor `determineWinner` to use `compareHands` while preserving messages.
+- [ ] Run focused test and typecheck.
+- [ ] Commit with `refactor: share duel hand comparison`.
+
+### Task 3: Duel Equity Engine
+
+**Files:**
+- Create: `app/features/game/engine/equityEngine.ts`
+- Create: `app/features/game/engine/equityEngine.test.ts`
+
+- [ ] Write tests for no player 1 selection, public-information equity after player 1 selection, hidden-group anti-spoiler behavior, exact post-player-2 result, and tie-break behavior.
+- [ ] Run focused test and confirm it fails before implementation.
+- [ ] Implement deterministic 3-card combination enumeration from a full deck excluding only player 1 selected cards.
+- [ ] Implement exact result when both selected sides exist.
+- [ ] Run focused test and typecheck.
+- [ ] Commit with `feat: add duel equity engine`.
+
+### Task 4: Game UI
+
+**Files:**
+- Modify: `app/routes/game.tsx`
+- Modify: `app/features/game/components/GameArenaScreen.tsx`
+
+- [ ] Compute `duelEquity` from `duelData`.
+- [ ] Pass `duelEquity` to `GameArenaScreen`.
+- [ ] Render a compact, non-interactive equity panel only when equity is non-null.
+- [ ] Use `player1Name` and `player2Name`; before player 2 selection, use `currentPlayerName` for player 2.
+- [ ] Run typecheck and lint.
+- [ ] Commit with `feat: show duel equity`.
+
+### Task 5: Final Verification
+
+- [ ] Run `npm run test`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run typecheck`.
+- [ ] Run `npm run build`.
+- [ ] Start `npm run dev` and manually verify the duel equity lifecycle.

--- a/docs/superpowers/specs/2026-05-16-duel-equity-design.md
+++ b/docs/superpowers/specs/2026-05-16-duel-equity-design.md
@@ -1,0 +1,108 @@
+# Current-Duel Equity for Thor's 3Key
+
+**Created**: 2026-05-16
+**Status**: Approved
+**GitHub Issue**: https://github.com/shoppinh/Thor-s-3Key/issues/30
+
+## Goal
+
+Add a poker-style equity display for the current duel. After the first player chooses a card group, the game should show each player's chance to win the duel as a percentage. After the second player chooses, the display should update to the exact result.
+
+The feature must preserve suspense. It must not reveal whether the hidden generated card groups are strong or weak before the second player chooses.
+
+## Scope
+
+This feature covers only the current duel. It does not estimate match-level or whole-game winning probability.
+
+## Equity Model
+
+Use an anti-spoiler equity model based on public information:
+
+- Before player 1 chooses, do not show duel equity because there is no selected hand to evaluate.
+- After player 1 chooses, compare player 1's selected 3-card hand against every possible 3-card hand from a full deck excluding only player 1's selected cards.
+- Do not use the remaining already-generated hidden card groups for the pre-reveal equity calculation.
+- After player 2 chooses, update the equity to the exact result: winner `100%`, loser `0%`.
+
+This mirrors poker equity: percentages are based on known cards and possible unknown outcomes, not on hidden cards already known internally by the app.
+
+## Architecture
+
+Add a pure game engine module:
+
+```text
+app/features/game/engine/equityEngine.ts
+```
+
+The module should expose a function that accepts the current duel context and returns player equity:
+
+```ts
+type DuelEquity = {
+  player1: { winRate: number; equity: number };
+  player2: { winRate: number; equity: number };
+};
+```
+
+The implementation should reuse existing game rules from `app/utils/gameUtil.ts`, especially:
+
+- `createDeck`
+- `calculateSum`
+- `getCardHighestSuitAndValue`
+- the same winner comparison semantics used by `determineWinner`
+
+If the current winner comparison is difficult to reuse without translation strings, extract a small pure helper that compares two hands and returns a winner side. `determineWinner` can keep building localized messages on top of that helper.
+
+## Data Flow
+
+1. `app/routes/game.tsx` owns the current `DuelData`.
+2. When player 1 chooses, the selected player data is stored in `DuelData`.
+3. The route or a memoized selector calls the equity engine with the current duel state.
+4. The calculated equity is passed to the game UI component.
+5. After player 2 chooses, the same display is updated with the exact winner and loser percentages.
+
+The equity calculation should be deterministic for the same input. Prefer enumerating all possible 3-card combinations over random simulation because the deck is small.
+
+## UI
+
+Add a compact equity display in the active duel area, likely near `RoundStatus`.
+
+Example after player 1 chooses:
+
+```text
+Alice 62% | Bob 38%
+```
+
+Example after player 2 chooses:
+
+```text
+Alice 100% | Bob 0%
+```
+
+The display should use player names when available. It should avoid showing a misleading percentage before player 1 chooses.
+
+## Edge Cases
+
+- If player 1 has not selected a side, return no equity.
+- If player 1 selected cards are incomplete or invalid, return no equity.
+- If player 2 has selected a side, calculate exact equity from the two selected hands.
+- Ties should follow the existing game tie-break rules, including suit hierarchy and ace handling.
+- Power-up effects that change selectable groups should not affect the anti-spoiler pre-reveal equity unless they change public selected cards.
+- Life Shield affects elimination, not duel win probability, so it should not change equity.
+
+## Testing
+
+Add Vitest coverage for the pure equity engine.
+
+Required cases:
+
+- No equity before player 1 chooses.
+- Player 1 selected only: equity is computed from all valid possible opponent hands excluding player 1's selected cards.
+- Player 2 selected: winner receives `100%` and loser receives `0%`.
+- Equal sums use the same highest-card and suit tie-break behavior as the game.
+- Player 1 choosing a weak hand does not force `0%` unless every possible unknown opponent hand beats it.
+
+## Non-Goals
+
+- Whole-game or match-level equity.
+- Revealing equity based on the real hidden generated groups before player 2 chooses.
+- Artificial clamping such as forcing minimum hype percentages.
+- AI-based recommendations or strategic advice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "match-sorter": "^6.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sort-by": "^0.0.2",
+        "sort-by": "^1.2.0",
         "tiny-invariant": "^1.3.1"
       },
       "devDependencies": {
@@ -31,7 +31,8 @@
         "prettier": "3.3.3",
         "typescript": "^5.1.6",
         "vite": "^5.1.4",
-        "vite-tsconfig-paths": "^4.3.1"
+        "vite-tsconfig-paths": "^4.3.1",
+        "vitest": "^4.1.6"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -528,6 +529,40 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -1235,10 +1270,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1284,6 +1320,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1398,6 +1453,16 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2117,6 +2182,288 @@
         "web-streams-polyfill": "^3.1.1"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -2473,6 +2820,24 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -2480,6 +2845,17 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/cookie": {
@@ -2496,6 +2872,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2556,12 +2939,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/prop-types": {
@@ -3280,6 +3664,106 @@
       "integrity": "sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==",
       "dev": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@web3-storage/multipart-parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -3596,6 +4080,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -3979,6 +4473,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4581,6 +5085,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -5710,6 +6224,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -7362,6 +7886,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
@@ -7485,6 +8282,16 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-extensions": {
@@ -8893,6 +9700,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/object-path": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.6.0.tgz",
+      "integrity": "sha512-fxrwsCFi3/p+LeLOAwo/wyRMODZxdGBtUlWRzsEpsUVrisZbEfZ21arxLGfaWfcnqb8oHPNihIb4XPE8CQPN5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/object.assign": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
@@ -8973,6 +9789,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -9329,9 +10156,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.45",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -9347,10 +10174,11 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -10085,6 +10913,40 @@
         "node": "*"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -10420,6 +11282,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -10436,10 +11305,13 @@
       }
     },
     "node_modules/sort-by": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-0.0.2.tgz",
-      "integrity": "sha512-iOX5oHA4a0eqTMFiWrHYqv924UeRKFBLhym7iwSVG37Egg2wApgZKAjyzM9WZjMwKv6+8Zi+nIaJ7FYsO9EkoA==",
-      "license": "MIT"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sort-by/-/sort-by-1.2.0.tgz",
+      "integrity": "sha512-aRyW65r3xMnf4nxJRluCg0H/woJpksU1dQxRtXYzau30sNBOmf5HACpDd9MZDhKh7ALQ5FgSOfMPwZEtUmMqcg==",
+      "license": "MIT",
+      "dependencies": {
+        "object-path": "0.6.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.4",
@@ -10529,6 +11401,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10537,6 +11416,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -11022,6 +11908,81 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -11113,6 +12074,14 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/turbo-stream": {
       "version": "2.4.1",
@@ -11275,10 +12244,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -12123,6 +13093,228 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -12242,6 +13434,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "remix-serve build/server/index.js",
+    "test": "vitest run",
     "typecheck": "tsc",
     "prettier-format": "prettier --config .prettierrc 'app/**/*.tsx' --write"
   },
@@ -37,7 +38,8 @@
     "prettier": "3.3.3",
     "typescript": "^5.1.6",
     "vite": "^5.1.4",
-    "vite-tsconfig-paths": "^4.3.1"
+    "vite-tsconfig-paths": "^4.3.1",
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: 'node'
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from 'vitest/config';
-import tsconfigPaths from 'vite-tsconfig-paths';
+import path from 'node:path';
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      '~': path.resolve(process.cwd(), 'app')
+    }
+  },
   test: {
     globals: true,
     environment: 'node'


### PR DESCRIPTION
## Summary
- Add Vitest setup and focused tests for hand comparison and duel equity.
- Add a pure anti-spoiler equity engine for current duel odds.
- Show compact player equity percentages during the duel and exact 100/0 after both players select.
- Clean up existing lint blockers so full verification passes.

## Test Plan
- npm run test
- npm run lint
- npm run typecheck
- npm run build

Closes #30