### PR TITLE
Account for power-ups in duel equity

### DIFF
--- a/app/features/game/engine/equityEngine.test.ts
+++ b/app/features/game/engine/equityEngine.test.ts
@@ -3,6 +3,8 @@ import { calculateDuelEquity } from '~/features/game/engine/equityEngine';
 import { createInitialDuelData } from '~/features/game/state/initialState';
 import DuelData from '~/models/DuelData';
 
+const card = (value: number, suit: string) => ({ value, suit });
+
 const withPlayer1Selection = (
   updates: Partial<DuelData> = {}
 ): DuelData => ({
@@ -29,6 +31,20 @@ const withPlayer1Selection = (
   },
   ...updates
 });
+
+const withRevealTwo = (updates: Partial<DuelData> = {}): DuelData =>
+  withPlayer1Selection({
+    revealedCards: {
+      topLeft: [card(9, '♦'), card(9, '♥'), card(0, '')],
+      bottomLeft: [card(1, '♦'), card(1, '♥'), card(0, '')],
+      topRight: [card(2, '♣'), card(3, '♣'), card(0, '')],
+      bottomRight: [card(8, '♣'), card(1, '♣'), card(0, '')]
+    },
+    bottomLeftCards: [card(1, '♦'), card(1, '♥'), card(9, '♠')],
+    topRightCards: [card(2, '♣'), card(3, '♣'), card(4, '♣')],
+    bottomRightCards: [card(8, '♣'), card(1, '♣'), card(9, '♥')],
+    ...updates
+  });
 
 describe('calculateDuelEquity', () => {
   it('returns null before player 1 selects a side', () => {
@@ -75,6 +91,86 @@ describe('calculateDuelEquity', () => {
     expect(calculateDuelEquity(firstHiddenLayout)).toEqual(
       calculateDuelEquity(secondHiddenLayout)
     );
+  });
+
+  it('uses Reveal Two visible cards to constrain pre-player-2 equity', () => {
+    const genericEquity = calculateDuelEquity(withPlayer1Selection());
+    const revealTwoEquity = calculateDuelEquity(withRevealTwo());
+
+    expect(genericEquity).not.toBeNull();
+    expect(revealTwoEquity).not.toBeNull();
+    expect(revealTwoEquity?.player1.winRate).not.toBe(
+      genericEquity?.player1.winRate
+    );
+    expect(revealTwoEquity?.player2.winRate).toBe(
+      100 - (revealTwoEquity?.player1.winRate ?? 0)
+    );
+  });
+
+  it('does not use hidden third cards when Reveal Two is active', () => {
+    const firstHiddenLayout = withRevealTwo({
+      bottomLeftCards: [card(1, '♦'), card(1, '♥'), card(9, '♠')],
+      topRightCards: [card(2, '♣'), card(3, '♣'), card(4, '♣')],
+      bottomRightCards: [card(8, '♣'), card(1, '♣'), card(9, '♥')]
+    });
+    const secondHiddenLayout = withRevealTwo({
+      bottomLeftCards: [card(1, '♦'), card(1, '♥'), card(2, '♠')],
+      topRightCards: [card(2, '♣'), card(3, '♣'), card(9, '♣')],
+      bottomRightCards: [card(8, '♣'), card(1, '♣'), card(3, '♥')]
+    });
+
+    expect(calculateDuelEquity(firstHiddenLayout)).toEqual(
+      calculateDuelEquity(secondHiddenLayout)
+    );
+  });
+
+  it('excludes Remove Worst slots from Reveal Two equity', () => {
+    const allSlotsEquity = calculateDuelEquity(withRevealTwo());
+    const removedStrongSlotEquity = calculateDuelEquity(
+      withRevealTwo({
+        removedWorstGroups: ['bottom-left']
+      })
+    );
+
+    expect(allSlotsEquity).not.toBeNull();
+    expect(removedStrongSlotEquity).not.toBeNull();
+    expect(removedStrongSlotEquity?.player1.winRate).not.toBe(
+      allSlotsEquity?.player1.winRate
+    );
+  });
+
+  it('returns null after Second Chance resets player 1 selection', () => {
+    expect(
+      calculateDuelEquity(
+        withRevealTwo({
+          duelIndex: 0,
+          player1Name: '?',
+          player1SideSelected: undefined,
+          player2Name: '',
+          player2SideSelected: undefined,
+          topLeftPlayerData: {
+            name: '?',
+            team: '',
+            sum: 7,
+            cards: [card(9, '♦'), card(9, '♥'), card(9, '♠')]
+          }
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('returns public equity after Second Chance resets player 2 selection', () => {
+    const equity = calculateDuelEquity(
+      withRevealTwo({
+        duelIndex: 1,
+        player2Name: '',
+        player2SideSelected: undefined
+      })
+    );
+
+    expect(equity).not.toBeNull();
+    expect(equity?.player1.winRate).toBeGreaterThan(0);
+    expect(equity?.player1.winRate).toBeLessThan(100);
   });
 
   it('returns exact equity after player 2 selects a losing hand', () => {

--- a/app/features/game/engine/equityEngine.ts
+++ b/app/features/game/engine/equityEngine.ts
@@ -14,12 +14,22 @@ export type DuelEquity = {
   player2: DuelEquitySide;
 };
 
+const SIDES: Side[] = ['top-left', 'bottom-left', 'top-right', 'bottom-right'];
+
 const hasCompleteHand = (cards: Card[]): boolean => {
   return cards.length === 3 && cards.every((card) => card.value > 0 && card.suit);
 };
 
+const hasPublicCard = (card: Card): boolean => {
+  return card.value > 0 && Boolean(card.suit);
+};
+
 const isSameCard = (left: Card, right: Card): boolean => {
   return left.value === right.value && left.suit === right.suit;
+};
+
+const containsCard = (cards: Card[], target: Card): boolean => {
+  return cards.some((card) => isSameCard(card, target));
 };
 
 const createEquity = (player1WinRate: number): DuelEquity => {
@@ -50,6 +60,23 @@ const createThreeCardCombinations = (cards: Card[]): Card[][] => {
   return combinations;
 };
 
+const getRevealedCardsBySide = (
+  duelData: DuelData,
+  side: Side
+): Card[] => {
+  if (side === 'top-left') return duelData.revealedCards.topLeft;
+  if (side === 'bottom-left') return duelData.revealedCards.bottomLeft;
+  if (side === 'top-right') return duelData.revealedCards.topRight;
+  return duelData.revealedCards.bottomRight;
+};
+
+const getLegalOpponentSides = (duelData: DuelData): Side[] => {
+  const removedSides = new Set(duelData.removedWorstGroups || []);
+  return SIDES.filter((side) => {
+    return side !== duelData.player1SideSelected && !removedSides.has(side);
+  });
+};
+
 const getSelectedCards = (
   duelData: DuelData,
   selectedSide?: Side
@@ -64,15 +91,68 @@ const getSelectedCards = (
 
 const calculatePlayer1PublicWinRate = (player1Cards: Card[]): number => {
   const possibleOpponentCards = createDeck().filter(
-    (card) => !player1Cards.some((selected) => isSameCard(card, selected))
+    (card) => !containsCard(player1Cards, card)
   );
   const possibleOpponentHands =
     createThreeCardCombinations(possibleOpponentCards);
-  const player1Wins = possibleOpponentHands.filter(
+
+  return (
+    calculatePlayer1WinRateAgainstHands(player1Cards, possibleOpponentHands) ??
+    0
+  );
+};
+
+const createRevealTwoOpponentHands = (
+  duelData: DuelData,
+  player1Cards: Card[]
+): Card[][] => {
+  const publicCards = getLegalOpponentSides(duelData).flatMap((side) =>
+    getRevealedCardsBySide(duelData, side).filter(hasPublicCard)
+  );
+
+  const knownCards = [...player1Cards, ...publicCards];
+  const unknownThirdCards = createDeck().filter(
+    (candidate) => !containsCard(knownCards, candidate)
+  );
+
+  return getLegalOpponentSides(duelData).flatMap((side) => {
+    const visibleCards = getRevealedCardsBySide(duelData, side).filter(
+      hasPublicCard
+    );
+
+    if (visibleCards.length !== 2) {
+      return [];
+    }
+
+    return unknownThirdCards.map((thirdCard) => [...visibleCards, thirdCard]);
+  });
+};
+
+const calculatePlayer1WinRateAgainstHands = (
+  player1Cards: Card[],
+  opponentHands: Card[][]
+): number | null => {
+  if (opponentHands.length === 0) {
+    return null;
+  }
+
+  const player1Wins = opponentHands.filter(
     (opponentCards) => compareHands(player1Cards, opponentCards) === 'player1'
   ).length;
 
-  return Math.round((player1Wins / possibleOpponentHands.length) * 100);
+  return Math.round((player1Wins / opponentHands.length) * 100);
+};
+
+const calculatePlayer1PreSelectionWinRate = (
+  duelData: DuelData,
+  player1Cards: Card[]
+): number => {
+  const revealTwoWinRate = calculatePlayer1WinRateAgainstHands(
+    player1Cards,
+    createRevealTwoOpponentHands(duelData, player1Cards)
+  );
+
+  return revealTwoWinRate ?? calculatePlayer1PublicWinRate(player1Cards);
 };
 
 export const calculateDuelEquity = (
@@ -98,5 +178,7 @@ export const calculateDuelEquity = (
     );
   }
 
-  return createEquity(calculatePlayer1PublicWinRate(player1Cards));
+  return createEquity(
+    calculatePlayer1PreSelectionWinRate(duelData, player1Cards)
+  );
 };

--- a/docs/superpowers/plans/2026-05-16-power-up-aware-duel-equity.md
+++ b/docs/superpowers/plans/2026-05-16-power-up-aware-duel-equity.md
@@ -1,0 +1,401 @@
+# Power-Up Aware Duel Equity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make duel equity react to `Reveal Two` and `Remove Worst` using only public cards and legal selectable slots.
+
+**Architecture:** Keep the feature inside the pure equity engine. Add range-building helpers that turn `duelData.revealedCards` into possible opponent hands, then have `calculateDuelEquity` choose between exact post-selection equity, Reveal Two constrained equity, and the existing generic public estimate.
+
+**Tech Stack:** Remix, React, TypeScript, Vitest.
+
+---
+
+## File Structure
+
+- Modify: `app/features/game/engine/equityEngine.ts`
+  - Add helpers for card identity, visible-card validation, legal opponent slots, and Reveal Two opponent hand generation.
+  - Keep `calculateDuelEquity(duelData: DuelData): DuelEquity | null` as the public API.
+- Modify: `app/features/game/engine/equityEngine.test.ts`
+  - Add tests for Reveal Two constrained equity, hidden third-card safety, Remove Worst exclusion, and Second Chance reset states.
+
+## Task 1: Add Failing Tests for Power-Up Aware Equity
+
+**Files:**
+- Modify: `app/features/game/engine/equityEngine.test.ts`
+
+- [ ] **Step 1: Add a local card helper and two Reveal Two fixtures**
+
+Add this helper after the imports:
+
+```ts
+const card = (value: number, suit: string) => ({ value, suit });
+```
+
+Add these helpers after `withPlayer1Selection`:
+
+```ts
+const withRevealTwo = (updates: Partial<DuelData> = {}): DuelData =>
+  withPlayer1Selection({
+    revealedCards: {
+      topLeft: [card(9, '♦'), card(9, '♥'), card(0, '')],
+      bottomLeft: [card(1, '♦'), card(1, '♥'), card(0, '')],
+      topRight: [card(2, '♣'), card(3, '♣'), card(0, '')],
+      bottomRight: [card(8, '♣'), card(1, '♣'), card(0, '')]
+    },
+    bottomLeftCards: [card(1, '♦'), card(1, '♥'), card(9, '♠')],
+    topRightCards: [card(2, '♣'), card(3, '♣'), card(4, '♣')],
+    bottomRightCards: [card(8, '♣'), card(1, '♣'), card(9, '♥')],
+    ...updates
+  });
+```
+
+Expected: tests still compile, but no behavior changes yet.
+
+- [ ] **Step 2: Add a test proving Reveal Two changes the generic estimate**
+
+Add this test before the exact post-selection tests:
+
+```ts
+it('uses Reveal Two visible cards to constrain pre-player-2 equity', () => {
+  const genericEquity = calculateDuelEquity(withPlayer1Selection());
+  const revealTwoEquity = calculateDuelEquity(withRevealTwo());
+
+  expect(genericEquity).not.toBeNull();
+  expect(revealTwoEquity).not.toBeNull();
+  expect(revealTwoEquity?.player1.winRate).not.toBe(
+    genericEquity?.player1.winRate
+  );
+  expect(revealTwoEquity?.player2.winRate).toBe(
+    100 - (revealTwoEquity?.player1.winRate ?? 0)
+  );
+});
+```
+
+- [ ] **Step 3: Add a hidden third-card anti-leak test**
+
+Add this test after the Reveal Two constrained equity test:
+
+```ts
+it('does not use hidden third cards when Reveal Two is active', () => {
+  const firstHiddenLayout = withRevealTwo({
+    bottomLeftCards: [card(1, '♦'), card(1, '♥'), card(9, '♠')],
+    topRightCards: [card(2, '♣'), card(3, '♣'), card(4, '♣')],
+    bottomRightCards: [card(8, '♣'), card(1, '♣'), card(9, '♥')]
+  });
+  const secondHiddenLayout = withRevealTwo({
+    bottomLeftCards: [card(1, '♦'), card(1, '♥'), card(2, '♠')],
+    topRightCards: [card(2, '♣'), card(3, '♣'), card(9, '♣')],
+    bottomRightCards: [card(8, '♣'), card(1, '♣'), card(3, '♥')]
+  });
+
+  expect(calculateDuelEquity(firstHiddenLayout)).toEqual(
+    calculateDuelEquity(secondHiddenLayout)
+  );
+});
+```
+
+- [ ] **Step 4: Add a Remove Worst slot exclusion test**
+
+Add this test after the hidden third-card anti-leak test:
+
+```ts
+it('excludes Remove Worst slots from Reveal Two equity', () => {
+  const allSlotsEquity = calculateDuelEquity(withRevealTwo());
+  const removedStrongSlotEquity = calculateDuelEquity(
+    withRevealTwo({
+      removedWorstGroups: ['bottom-left']
+    })
+  );
+
+  expect(allSlotsEquity).not.toBeNull();
+  expect(removedStrongSlotEquity).not.toBeNull();
+  expect(removedStrongSlotEquity?.player1.winRate).not.toBe(
+    allSlotsEquity?.player1.winRate
+  );
+});
+```
+
+- [ ] **Step 5: Add Second Chance reset state tests**
+
+Add these tests after the Remove Worst slot exclusion test:
+
+```ts
+it('returns null after Second Chance resets player 1 selection', () => {
+  expect(
+    calculateDuelEquity(
+      withRevealTwo({
+        duelIndex: 0,
+        player1Name: '?',
+        player1SideSelected: undefined,
+        player2Name: '',
+        player2SideSelected: undefined,
+        topLeftPlayerData: {
+          name: '?',
+          team: '',
+          sum: 7,
+          cards: [card(9, '♦'), card(9, '♥'), card(9, '♠')]
+        }
+      })
+    )
+  ).toBeNull();
+});
+
+it('returns public equity after Second Chance resets player 2 selection', () => {
+  const equity = calculateDuelEquity(
+    withRevealTwo({
+      duelIndex: 1,
+      player2Name: '',
+      player2SideSelected: undefined
+    })
+  );
+
+  expect(equity).not.toBeNull();
+  expect(equity?.player1.winRate).toBeGreaterThan(0);
+  expect(equity?.player1.winRate).toBeLessThan(100);
+});
+```
+
+- [ ] **Step 6: Run the targeted test and verify it fails**
+
+Run:
+
+```bash
+npm test -- app/features/game/engine/equityEngine.test.ts
+```
+
+Expected: FAIL. The new Reveal Two and Remove Worst tests should fail because the current engine ignores `duelData.revealedCards` and `duelData.removedWorstGroups`.
+
+## Task 2: Implement Reveal Two Opponent Ranges
+
+**Files:**
+- Modify: `app/features/game/engine/equityEngine.ts`
+
+- [ ] **Step 1: Add side list and stricter public-card helpers**
+
+Replace the current `hasCompleteHand` and `isSameCard` helper block with:
+
+```ts
+const SIDES: Side[] = ['top-left', 'bottom-left', 'top-right', 'bottom-right'];
+
+const hasCompleteHand = (cards: Card[]): boolean => {
+  return cards.length === 3 && cards.every((card) => card.value > 0 && card.suit);
+};
+
+const hasPublicCard = (card: Card): boolean => {
+  return card.value > 0 && Boolean(card.suit);
+};
+
+const isSameCard = (left: Card, right: Card): boolean => {
+  return left.value === right.value && left.suit === right.suit;
+};
+
+const containsCard = (cards: Card[], target: Card): boolean => {
+  return cards.some((card) => isSameCard(card, target));
+};
+```
+
+- [ ] **Step 2: Add helpers for revealed cards and selectable opponent slots**
+
+Add these helpers after `createThreeCardCombinations`:
+
+```ts
+const getRevealedCardsBySide = (
+  duelData: DuelData,
+  side: Side
+): Card[] => {
+  if (side === 'top-left') return duelData.revealedCards.topLeft;
+  if (side === 'bottom-left') return duelData.revealedCards.bottomLeft;
+  if (side === 'top-right') return duelData.revealedCards.topRight;
+  return duelData.revealedCards.bottomRight;
+};
+
+const getLegalOpponentSides = (duelData: DuelData): Side[] => {
+  const removedSides = new Set(duelData.removedWorstGroups || []);
+  return SIDES.filter((side) => {
+    return side !== duelData.player1SideSelected && !removedSides.has(side);
+  });
+};
+```
+
+- [ ] **Step 3: Add the Reveal Two hand generator**
+
+Add this helper after `calculatePlayer1PublicWinRate`:
+
+```ts
+const createRevealTwoOpponentHands = (
+  duelData: DuelData,
+  player1Cards: Card[]
+): Card[][] => {
+  const publicCards = getLegalOpponentSides(duelData).flatMap((side) =>
+    getRevealedCardsBySide(duelData, side).filter(hasPublicCard)
+  );
+
+  const knownCards = [...player1Cards, ...publicCards];
+  const unknownThirdCards = createDeck().filter(
+    (candidate) => !containsCard(knownCards, candidate)
+  );
+
+  return getLegalOpponentSides(duelData).flatMap((side) => {
+    const visibleCards = getRevealedCardsBySide(duelData, side).filter(
+      hasPublicCard
+    );
+
+    if (visibleCards.length !== 2) {
+      return [];
+    }
+
+    return unknownThirdCards.map((thirdCard) => [...visibleCards, thirdCard]);
+  });
+};
+```
+
+- [ ] **Step 4: Add a shared win-rate helper**
+
+Add this helper after `createRevealTwoOpponentHands`:
+
+```ts
+const calculatePlayer1WinRateAgainstHands = (
+  player1Cards: Card[],
+  opponentHands: Card[][]
+): number | null => {
+  if (opponentHands.length === 0) {
+    return null;
+  }
+
+  const player1Wins = opponentHands.filter(
+    (opponentCards) => compareHands(player1Cards, opponentCards) === 'player1'
+  ).length;
+
+  return Math.round((player1Wins / opponentHands.length) * 100);
+};
+```
+
+- [ ] **Step 5: Refactor the generic public calculation through the shared helper**
+
+Replace `calculatePlayer1PublicWinRate` with:
+
+```ts
+const calculatePlayer1PublicWinRate = (player1Cards: Card[]): number => {
+  const possibleOpponentCards = createDeck().filter(
+    (card) => !containsCard(player1Cards, card)
+  );
+  const possibleOpponentHands =
+    createThreeCardCombinations(possibleOpponentCards);
+
+  return calculatePlayer1WinRateAgainstHands(player1Cards, possibleOpponentHands) ?? 0;
+};
+```
+
+- [ ] **Step 6: Route pre-player-2 calculation through Reveal Two when available**
+
+Add this helper after `calculatePlayer1PublicWinRate`:
+
+```ts
+const calculatePlayer1PreSelectionWinRate = (
+  duelData: DuelData,
+  player1Cards: Card[]
+): number => {
+  const revealTwoWinRate = calculatePlayer1WinRateAgainstHands(
+    player1Cards,
+    createRevealTwoOpponentHands(duelData, player1Cards)
+  );
+
+  return revealTwoWinRate ?? calculatePlayer1PublicWinRate(player1Cards);
+};
+```
+
+Replace the final return in `calculateDuelEquity` with:
+
+```ts
+  return createEquity(calculatePlayer1PreSelectionWinRate(duelData, player1Cards));
+```
+
+- [ ] **Step 7: Run the targeted test and verify it passes**
+
+Run:
+
+```bash
+npm test -- app/features/game/engine/equityEngine.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the equity engine enhancement**
+
+Run:
+
+```bash
+git add app/features/game/engine/equityEngine.ts app/features/game/engine/equityEngine.test.ts
+git commit -m "feat: account for power-ups in duel equity"
+```
+
+## Task 3: Verify the Feature Story
+
+**Files:**
+- Verify: `app/features/game/engine/equityEngine.ts`
+- Verify: `app/features/game/engine/equityEngine.test.ts`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run TypeScript checking**
+
+Run:
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS or only pre-existing warnings unrelated to `equityEngine.ts` and `equityEngine.test.ts`.
+
+- [ ] **Step 4: Manually inspect anti-spoiler behavior in code**
+
+Confirm these facts before finishing:
+
+```text
+equityEngine.ts does not read topLeftCards, bottomLeftCards, topRightCards, or bottomRightCards when calculating Reveal Two pre-player-2 equity.
+equityEngine.ts does read duelData.revealedCards and duelData.removedWorstGroups when calculating Reveal Two pre-player-2 equity.
+calculateDuelEquity still returns exact 100/0 equity after player2SideSelected is present.
+```
+
+- [ ] **Step 5: Commit any verification-only fixes**
+
+If verification required formatting or test fixes, run:
+
+```bash
+git add app/features/game/engine/equityEngine.ts app/features/game/engine/equityEngine.test.ts
+git commit -m "test: cover power-up aware duel equity"
+```
+
+If there are no additional changes after Task 2, skip this commit step.
+
+## Self-Review
+
+Spec coverage:
+
+- Reveal Two constrained equity is covered by Task 1 tests and Task 2 range generation.
+- Hidden third-card safety is covered by Task 1 hidden-layout test and Task 3 code inspection.
+- Remove Worst slot exclusion is covered by Task 1 test and Task 2 legal-side filtering.
+- Second Chance behavior is covered by Task 1 reset-state tests because the equity engine follows selection state.
+- Life Shield requires no code because the equity engine does not read `lifeShieldUsedBy`.
+
+Placeholder scan: no placeholder markers remain in this plan.
+
+Type consistency: the plan uses existing `DuelData`, `Card`, `Side`, `calculateDuelEquity`, `compareHands`, `createDeck`, `player1SideSelected`, `player2SideSelected`, `revealedCards`, and `removedWorstGroups` names.

--- a/docs/superpowers/specs/2026-05-16-duel-equity-design.md
+++ b/docs/superpowers/specs/2026-05-16-duel-equity-design.md
@@ -25,6 +25,25 @@ Use an anti-spoiler equity model based on public information:
 
 This mirrors poker equity: percentages are based on known cards and possible unknown outcomes, not on hidden cards already known internally by the app.
 
+## Power-Up Aware Equity
+
+Power-ups may refine equity only through public information and legal choices. The equity engine must never use face-down generated cards before player 2 selects a hand.
+
+When `Reveal Two` is active, the pre-player-2 equity should become board-aware while staying hidden-card safe:
+
+- For each still-selectable opponent slot, use the two publicly revealed cards in `duelData.revealedCards`.
+- Treat the third card in that slot as unknown.
+- Build possible opponent hands as the two visible cards plus every legal unknown third card from the deck.
+- Exclude player 1's selected cards and all other publicly visible cards from the unknown-third-card pool.
+- Exclude slots listed in `duelData.removedWorstGroups`.
+- If no legal revealed-two opponent hands can be generated, fall back to the generic public-information calculation rather than showing a misleading exact value.
+
+Other power-up behavior:
+
+- `Remove Worst` changes equity only by removing disabled slots from the legal opponent range.
+- `Second Chance` follows the reset duel state. If player 1's selection is reset, equity returns to `null`; if player 2's selection is reset, equity returns to the current public-information estimate.
+- `Life Shield` does not affect duel equity because it changes elimination consequences, not the duel winner.
+
 ## Architecture
 
 Add a pure game engine module:
@@ -61,6 +80,8 @@ If the current winner comparison is difficult to reuse without translation strin
 
 The equity calculation should be deterministic for the same input. Prefer enumerating all possible 3-card combinations over random simulation because the deck is small.
 
+When `Reveal Two` is active, `duelData.revealedCards` is the public source of truth for visible slot cards. The equity engine should derive opponent ranges from those public arrays and `duelData.removedWorstGroups`, not from the hidden `topLeftCards`, `bottomLeftCards`, `topRightCards`, or `bottomRightCards` third cards.
+
 ## UI
 
 Add a compact equity display in the active duel area, likely near `RoundStatus`.
@@ -85,7 +106,9 @@ The display should use player names when available. It should avoid showing a mi
 - If player 1 selected cards are incomplete or invalid, return no equity.
 - If player 2 has selected a side, calculate exact equity from the two selected hands.
 - Ties should follow the existing game tie-break rules, including suit hierarchy and ace handling.
-- Power-up effects that change selectable groups should not affect the anti-spoiler pre-reveal equity unless they change public selected cards.
+- Power-up effects should not affect anti-spoiler pre-reveal equity unless they change public information or legal choices.
+- Reveal Two should constrain the opponent range to still-selectable slots with two public cards and one unknown third card.
+- Remove Worst should exclude disabled slots from the Reveal Two opponent range.
 - Life Shield affects elimination, not duel win probability, so it should not change equity.
 
 ## Testing
@@ -99,6 +122,10 @@ Required cases:
 - Player 2 selected: winner receives `100%` and loser receives `0%`.
 - Equal sums use the same highest-card and suit tie-break behavior as the game.
 - Player 1 choosing a weak hand does not force `0%` unless every possible unknown opponent hand beats it.
+- Reveal Two changes pre-player-2 equity by using visible two-card slot prefixes.
+- Reveal Two does not leak hidden third cards: changing only the hidden third cards in the generated groups does not change pre-player-2 equity.
+- Remove Worst excludes the removed slot from Reveal Two equity.
+- Second Chance reset behavior returns equity to `null` or to the current public estimate according to the reset selection state.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary
- Constrain pre-player-2 duel equity with Reveal Two public card prefixes
- Exclude Remove Worst slots from Reveal Two opponent ranges
- Cover hidden third-card anti-leak behavior and Second Chance reset states

## Test Plan
- npm test
- npm run typecheck
- npm run lint