### PR TITLE
fix: reveal blank groups after duel ends and enlarge equity display

### DIFF
--- a/app/components/PlayerCardDrawer.test.ts
+++ b/app/components/PlayerCardDrawer.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getPlayerCardDrawerDisplayState } from './PlayerCardDrawer';
+
+const card = (value: number, suit: string) => ({ value, suit });
+
+describe('getPlayerCardDrawerDisplayState', () => {
+  it('shows full cards instead of a draw button for blank groups after duel finish', () => {
+    const coveredCards = [card(0, ''), card(0, ''), card(0, '')];
+    const fullCards = [card(1, '♦'), card(1, '♥'), card(9, '♠')];
+
+    const displayState = getPlayerCardDrawerDisplayState({
+      playerCards: [],
+      coveredCards,
+      fullCards,
+      isFinishDuel: true,
+      disabledByRemoveWorst: false
+    });
+
+    expect(displayState.cards).toEqual(fullCards);
+    expect(displayState.shouldShowDrawButton).toBe(false);
+    expect(displayState.canClickCards).toBe(false);
+  });
+});

--- a/app/components/PlayerCardDrawer.tsx
+++ b/app/components/PlayerCardDrawer.tsx
@@ -15,6 +15,7 @@ interface PlayerCardDrawerProps {
   className: string;
   duelData: DuelData;
   playerData: PlayerData;
+  fullCards: Card[];
   onSelect: () => void;
   side: 'left' | 'right';
   disabled: boolean;
@@ -26,6 +27,34 @@ interface PlayerCardDrawerProps {
   CARDS_COVER: Card[];
 }
 
+export const getPlayerCardDrawerDisplayState = ({
+  playerCards,
+  coveredCards,
+  fullCards,
+  isFinishDuel,
+  disabledByRemoveWorst
+}: {
+  playerCards: Card[];
+  coveredCards: Card[];
+  fullCards: Card[];
+  isFinishDuel: boolean;
+  disabledByRemoveWorst: boolean;
+}) => {
+  const isBlankHand = playerCards.length === 0;
+  const cards =
+    isBlankHand && isFinishDuel
+      ? fullCards
+      : playerCards.length > 0
+        ? playerCards
+        : coveredCards;
+
+  return {
+    cards,
+    shouldShowDrawButton: isBlankHand && !isFinishDuel,
+    canClickCards: isBlankHand && !isFinishDuel && !disabledByRemoveWorst
+  };
+};
+
 /**
  * Renders a player's card drawing interface with draw button, hand pointer, and card display
  */
@@ -33,6 +62,7 @@ const PlayerCardDrawer: React.FC<PlayerCardDrawerProps> = ({
   className,
   duelData,
   playerData,
+  fullCards,
   onSelect,
   side,
   disabled,
@@ -58,8 +88,13 @@ const PlayerCardDrawer: React.FC<PlayerCardDrawerProps> = ({
     return key ? disabled.has(key) : false;
   })();
   const isBlankHand = playerData.cards.length === 0;
-  const canClickDraw = isBlankHand && !disabledByRemoveWorst;
-  const shouldShowDrawButton = isBlankHand;
+  const displayState = getPlayerCardDrawerDisplayState({
+    playerCards: playerData.cards,
+    coveredCards: CARDS_COVER,
+    fullCards,
+    isFinishDuel: duelData.isFinishDuel,
+    disabledByRemoveWorst
+  });
   const isDrawDisabled = disabled || disabledByRemoveWorst;
 
   const containerStyle: React.CSSProperties = {
@@ -119,7 +154,7 @@ const PlayerCardDrawer: React.FC<PlayerCardDrawerProps> = ({
             justifyContent: 'center'
           }}
         >
-          {shouldShowDrawButton && (
+          {displayState.shouldShowDrawButton && (
             <>
               {/* Animated Hand Pointer */}
               <img
@@ -215,8 +250,8 @@ const PlayerCardDrawer: React.FC<PlayerCardDrawerProps> = ({
           }}
         >
           {renderTheCards(
-            playerData.cards.length > 0 ? playerData.cards : CARDS_COVER,
-            canClickDraw ? onSelect : undefined,
+            displayState.cards,
+            displayState.canClickCards ? onSelect : undefined,
             isDrawDisabled
           )}
         </div>

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -206,6 +206,7 @@ const GameArenaScreen = ({
               <PlayerCardDrawer
                 className={'mb-1'}
                 playerData={duelData.topLeftPlayerData}
+                fullCards={duelData.topLeftCards}
                 onSelect={() => onSelect('top-left')}
                 side="left"
                 duelData={duelData}
@@ -222,6 +223,7 @@ const GameArenaScreen = ({
               <PlayerCardDrawer
                 className={''}
                 playerData={duelData.bottomLeftPlayerData}
+                fullCards={duelData.bottomLeftCards}
                 onSelect={() => onSelect('bottom-left')}
                 side="left"
                 duelData={duelData}
@@ -242,6 +244,7 @@ const GameArenaScreen = ({
               <PlayerCardDrawer
                 className={'mb-1'}
                 playerData={duelData.topRightPlayerData}
+                fullCards={duelData.topRightCards}
                 onSelect={() => onSelect('top-right')}
                 side="right"
                 duelData={duelData}
@@ -258,6 +261,7 @@ const GameArenaScreen = ({
               <PlayerCardDrawer
                 className={''}
                 playerData={duelData.bottomRightPlayerData}
+                fullCards={duelData.bottomRightCards}
                 onSelect={() => onSelect('bottom-right')}
                 side="right"
                 duelData={duelData}

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -61,14 +61,18 @@ const GameArenaScreen = ({
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: '16px',
-            padding: '10px 16px',
-            margin: '0 auto 12px',
+            gap: '32px',
+            padding: '20px 40px',
+            margin: '0 auto 20px',
             background: 'var(--color-panel-bg)',
-            border: '1px solid var(--color-accent)',
+            border: '2px solid var(--color-accent)',
+            borderRadius: '12px',
             color: '#fff',
             fontFamily: 'var(--font-body)',
-            fontSize: '16px',
+            fontSize: '28px',
+            fontWeight: 'bold',
+            letterSpacing: '1px',
+            textShadow: '0 0 8px rgba(255,255,255,0.3)',
             position: 'relative',
             zIndex: 10
           }}
@@ -76,7 +80,7 @@ const GameArenaScreen = ({
           <span style={{ color: 'var(--color-primary)' }}>
             {player1EquityName}: {duelEquity.player1.winRate}%
           </span>
-          <span style={{ color: 'var(--color-accent)' }}>|</span>
+          <span style={{ color: 'var(--color-accent)', fontSize: '32px' }}>|</span>
           <span style={{ color: 'var(--color-secondary)' }}>
             {player2EquityName}: {duelEquity.player2.winRate}%
           </span>
@@ -88,14 +92,18 @@ const GameArenaScreen = ({
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
-            gap: '16px',
-            padding: '10px 16px',
-            margin: '0 auto 12px',
+            gap: '32px',
+            padding: '20px 40px',
+            margin: '0 auto 20px',
             background: 'var(--color-panel-bg)',
-            border: '1px solid var(--color-accent)',
+            border: '2px solid var(--color-accent)',
+            borderRadius: '12px',
             color: '#fff',
             fontFamily: 'var(--font-body)',
-            fontSize: '16px',
+            fontSize: '28px',
+            fontWeight: 'bold',
+            letterSpacing: '1px',
+            textShadow: '0 0 8px rgba(255,255,255,0.3)',
             position: 'relative',
             zIndex: 10,
             visibility: 'hidden'
@@ -104,7 +112,7 @@ const GameArenaScreen = ({
           <span style={{ color: 'var(--color-primary)' }}>
             {player1EquityName}: 0%
           </span>
-          <span style={{ color: 'var(--color-accent)' }}>|</span>
+          <span style={{ color: 'var(--color-accent)', fontSize: '32px' }}>|</span>
           <span style={{ color: 'var(--color-secondary)' }}>
             {player2EquityName}: 0%
           </span>


### PR DESCRIPTION
## Summary
Fixes a bug where blank (unselected) card groups remained face-down after a duel finished, and enlarges the duel-equity percentage display for better visibility on large screens.

## Changes
- `app/components/PlayerCardDrawer.tsx`: add `getPlayerCardDrawerDisplayState` helper and `fullCards` prop so blank groups reveal their actual cards once the duel ends
- `app/components/PlayerCardDrawer.test.ts`: add unit test for blank-hand display after duel finish
- `app/features/game/components/GameArenaScreen.tsx`: pass `fullCards` to all four drawers; increase equity panel font, padding, border, and add text-shadow for big-screen clarity

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 15/15 passed

## Notes / risks
None