### PR TITLE
Add undo-only history stack for active gameplay

### DIFF
--- a/app/components/RoundStatus.tsx
+++ b/app/components/RoundStatus.tsx
@@ -15,11 +15,17 @@ interface RoundStatusProps {
   team2Data: TeamData;
   isFinishDuel: boolean;
   duelData: DuelData;
-  nextRound: (team1: string[], team2: string[]) => void;
+  nextRound: (
+    team1: string[],
+    team2: string[],
+    shouldRecordHistory?: boolean
+  ) => void;
   onChanceClick: (
     teamName: TeamName,
     chanceType: ChanceType
   ) => void;
+  canUndo: boolean;
+  onUndo: () => void;
 }
 
 const RoundStatus: React.FC<RoundStatusProps> = ({
@@ -34,7 +40,9 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
   isFinishDuel,
   duelData,
   nextRound,
-  onChanceClick
+  onChanceClick,
+  canUndo,
+  onUndo
 }) => {
   const { t } = useLanguage();
 
@@ -417,6 +425,22 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
             )}
           </div>
         )}
+
+        <div style={{ marginTop: '12px' }}>
+          <button
+            onClick={onUndo}
+            disabled={!canUndo}
+            className="rpg-button secondary"
+            style={{
+              fontSize: '16px',
+              padding: '8px 28px',
+              opacity: canUndo ? 1 : 0.45,
+              cursor: canUndo ? 'pointer' : 'not-allowed'
+            }}
+          >
+            {t('game.undo')}
+          </button>
+        </div>
       </div>
 
       {/* Team 2 Status */}

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -26,12 +26,18 @@ type GameArenaScreenProps = {
     onCardClick?: () => void,
     disabled?: boolean
   ) => JSX.Element[];
-  nextRound: (team1: string[], team2: string[]) => void;
+  nextRound: (
+    team1: string[],
+    team2: string[],
+    shouldRecordHistory?: boolean
+  ) => void;
   onChanceClick: (
     teamName: TeamName,
     chanceType: ChanceType
   ) => void;
   duelEquity: DuelEquity | null;
+  canUndo: boolean;
+  onUndo: () => void;
 };
 
 const GameArenaScreen = ({
@@ -46,7 +52,9 @@ const GameArenaScreen = ({
   renderTheCards,
   nextRound,
   onChanceClick,
-  duelEquity
+  duelEquity,
+  canUndo,
+  onUndo
 }: GameArenaScreenProps) => {
   const { t } = useLanguage();
   const player1EquityName = duelData.player1Name;
@@ -374,6 +382,8 @@ const GameArenaScreen = ({
         duelData={duelData}
         nextRound={nextRound}
         onChanceClick={onChanceClick}
+        canUndo={canUndo}
+        onUndo={onUndo}
       />
     </>
   );

--- a/app/features/game/components/GameOverScreen.tsx
+++ b/app/features/game/components/GameOverScreen.tsx
@@ -2,9 +2,15 @@ import { useLanguage } from '~/contexts/LanguageContext';
 
 type GameOverScreenProps = {
   teamWinner: string;
+  canUndo: boolean;
+  onUndo: () => void;
 };
 
-const GameOverScreen = ({ teamWinner }: GameOverScreenProps) => {
+const GameOverScreen = ({
+  teamWinner,
+  canUndo,
+  onUndo
+}: GameOverScreenProps) => {
   const { t } = useLanguage();
   return (
     <div
@@ -66,6 +72,20 @@ const GameOverScreen = ({ teamWinner }: GameOverScreenProps) => {
             }}
           />
         </div>
+        <button
+          onClick={onUndo}
+          disabled={!canUndo}
+          className="rpg-button secondary"
+          style={{
+            marginTop: '24px',
+            fontSize: '18px',
+            padding: '10px 36px',
+            opacity: canUndo ? 1 : 0.45,
+            cursor: canUndo ? 'pointer' : 'not-allowed'
+          }}
+        >
+          {t('game.undo')}
+        </button>
       </div>
     </div>
   );

--- a/app/features/game/state/historyStack.test.ts
+++ b/app/features/game/state/historyStack.test.ts
@@ -3,6 +3,7 @@ import {
   HISTORY_STACK_LIMIT,
   createGameSnapshot,
   pushGameSnapshot,
+  shouldRecordGameSnapshot,
   type GameSnapshot
 } from '~/features/game/state/historyStack';
 import {
@@ -76,5 +77,13 @@ describe('history stack', () => {
 
     expect(snapshot.team1Data.players).toEqual([]);
     expect(snapshot.duelData.currentPlayerName).toBe('');
+  });
+
+  it('records snapshots only when undo is enabled during active gameplay', () => {
+    expect(shouldRecordGameSnapshot(true, 'gamePlaying')).toBe(true);
+    expect(shouldRecordGameSnapshot(false, 'gamePlaying')).toBe(false);
+    expect(shouldRecordGameSnapshot(true, 'setup')).toBe(false);
+    expect(shouldRecordGameSnapshot(true, 'gameLoading')).toBe(false);
+    expect(shouldRecordGameSnapshot(true, 'gameOver')).toBe(false);
   });
 });

--- a/app/features/game/state/historyStack.test.ts
+++ b/app/features/game/state/historyStack.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HISTORY_STACK_LIMIT,
+  createGameSnapshot,
+  pushGameSnapshot,
+  type GameSnapshot
+} from '~/features/game/state/historyStack';
+import {
+  createInitialDuelData,
+  createInitialTeamData
+} from '~/features/game/state/initialState';
+
+const createSnapshot = (roundNumber: number) =>
+  createGameSnapshot({
+    team1Data: createInitialTeamData(1, 'Team'),
+    team2Data: createInitialTeamData(2, 'Team'),
+    duelData: createInitialDuelData(),
+    teamWinner: '',
+    duelResult: '',
+    isFirstTurn: false,
+    gameState: 'gamePlaying',
+    roundNumber,
+    winStreaks: {}
+  });
+
+describe('history stack', () => {
+  it('excludes transient score classes from snapshots', () => {
+    const snapshot = createGameSnapshot({
+      team1Data: { ...createInitialTeamData(1, 'Team'), scoreClass: 'blink' },
+      team2Data: { ...createInitialTeamData(2, 'Team'), scoreClass: 'blink' },
+      duelData: createInitialDuelData(),
+      teamWinner: '',
+      duelResult: '',
+      isFirstTurn: true,
+      gameState: 'gamePlaying',
+      roundNumber: 1,
+      winStreaks: {}
+    });
+
+    expect(snapshot.team1Data.scoreClass).toBe('');
+    expect(snapshot.team2Data.scoreClass).toBe('');
+  });
+
+  it('caps the stack at the history limit', () => {
+    const stack = Array.from(
+      { length: HISTORY_STACK_LIMIT + 5 },
+      (_, index) => index
+    ).reduce(
+      (history, roundNumber) =>
+        pushGameSnapshot(history, createSnapshot(roundNumber)),
+      [] as GameSnapshot[]
+    );
+
+    expect(stack).toHaveLength(HISTORY_STACK_LIMIT);
+    expect(stack[0].roundNumber).toBe(5);
+    expect(stack[HISTORY_STACK_LIMIT - 1].roundNumber).toBe(54);
+  });
+
+  it('copies snapshot data so later mutations cannot leak into history', () => {
+    const team1Data = createInitialTeamData(1, 'Team');
+    const duelData = createInitialDuelData();
+    const snapshot = createGameSnapshot({
+      team1Data,
+      team2Data: createInitialTeamData(2, 'Team'),
+      duelData,
+      teamWinner: '',
+      duelResult: '',
+      isFirstTurn: true,
+      gameState: 'gamePlaying',
+      roundNumber: 1,
+      winStreaks: {}
+    });
+
+    team1Data.players.push('Late Player');
+    duelData.currentPlayerName = 'Late Player';
+
+    expect(snapshot.team1Data.players).toEqual([]);
+    expect(snapshot.duelData.currentPlayerName).toBe('');
+  });
+});

--- a/app/features/game/state/historyStack.ts
+++ b/app/features/game/state/historyStack.ts
@@ -44,3 +44,8 @@ export const pushGameSnapshot = (
   snapshot: GameSnapshot,
   limit = HISTORY_STACK_LIMIT
 ): GameSnapshot[] => [...historyStack, snapshot].slice(-limit);
+
+export const shouldRecordGameSnapshot = (
+  undoEnabled: boolean,
+  gameState: GameState
+): boolean => undoEnabled && gameState === 'gamePlaying';

--- a/app/features/game/state/historyStack.ts
+++ b/app/features/game/state/historyStack.ts
@@ -1,0 +1,46 @@
+import type { GameState } from '~/features/game/types/gameTypes';
+import type DuelData from '~/models/DuelData';
+import type { TeamData } from '~/models/TeamData';
+
+export const HISTORY_STACK_LIMIT = 50;
+
+export type GameSnapshot = {
+  team1Data: TeamData;
+  team2Data: TeamData;
+  duelData: DuelData;
+  teamWinner: string;
+  duelResult: string;
+  isFirstTurn: boolean;
+  gameState: GameState;
+  roundNumber: number;
+  winStreaks: Record<string, number>;
+};
+
+export type GameSnapshotInput = GameSnapshot;
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const createTeamSnapshot = (teamData: TeamData): TeamData => ({
+  ...clone(teamData),
+  scoreClass: ''
+});
+
+export const createGameSnapshot = (
+  state: GameSnapshotInput
+): GameSnapshot => ({
+  team1Data: createTeamSnapshot(state.team1Data),
+  team2Data: createTeamSnapshot(state.team2Data),
+  duelData: clone(state.duelData),
+  teamWinner: state.teamWinner,
+  duelResult: state.duelResult,
+  isFirstTurn: state.isFirstTurn,
+  gameState: state.gameState,
+  roundNumber: state.roundNumber,
+  winStreaks: clone(state.winStreaks)
+});
+
+export const pushGameSnapshot = (
+  historyStack: GameSnapshot[],
+  snapshot: GameSnapshot,
+  limit = HISTORY_STACK_LIMIT
+): GameSnapshot[] => [...historyStack, snapshot].slice(-limit);

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -53,6 +53,8 @@ export default {
     locked: 'Locked',
     isWinner: 'is winner',
     anonymous: 'ANONYMOUS',
+    enableUndo: 'Enable Host Undo',
+    enableUndoHint: 'Lets the host reverse gameplay mistakes during this match.',
     undo: 'UNDO',
     navigationWarning:
       'A game is in progress. Leaving now will lose the current game. Continue?'

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -52,7 +52,10 @@ export default {
     unknown: 'Unknown',
     locked: 'Locked',
     isWinner: 'is winner',
-    anonymous: 'ANONYMOUS'
+    anonymous: 'ANONYMOUS',
+    undo: 'UNDO',
+    navigationWarning:
+      'A game is in progress. Leaving now will lose the current game. Continue?'
   },
   powerups: {
     secondChanceTitle: 'Second Chance',

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -53,6 +53,8 @@ export default {
     locked: 'Đã khoá',
     isWinner: 'là đội chiến thắng',
     anonymous: 'Kẻ thế thân',
+    enableUndo: 'Bật hoàn tác cho chủ trò',
+    enableUndoHint: 'Cho phép chủ trò sửa lỗi bấm nhầm trong ván này.',
     undo: 'HOÀN TÁC',
     navigationWarning:
       'Trận đang diễn ra. Rời trang bây giờ sẽ mất ván hiện tại. Tiếp tục?'

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -52,7 +52,10 @@ export default {
     unknown: 'Đoán xem',
     locked: 'Đã khoá',
     isWinner: 'là đội chiến thắng',
-    anonymous: 'Kẻ thế thân'
+    anonymous: 'Kẻ thế thân',
+    undo: 'HOÀN TÁC',
+    navigationWarning:
+      'Trận đang diễn ra. Rời trang bây giờ sẽ mất ván hiện tại. Tiếp tục?'
   },
   powerups: {
     secondChanceTitle: 'Hải way xe',

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -32,6 +32,11 @@ import {
   createInitialTeamData
 } from '~/features/game/state/initialState';
 import {
+  createGameSnapshot,
+  pushGameSnapshot
+} from '~/features/game/state/historyStack';
+import type { GameSnapshot } from '~/features/game/state/historyStack';
+import {
   GameState,
   PowerUpsAllocation,
   SetupMode,
@@ -51,6 +56,7 @@ import {
   getStreakMessage,
   shuffleDeck
 } from '~/utils/gameUtil';
+import useNavigationGuard from '~/utils/hooks/useNavigationGuard';
 import ConfirmPopup from '../components/ConfirmPopup';
 import PowerupGuideModal from '../components/PowerupGuideModal';
 import Card from '../models/Card';
@@ -142,6 +148,64 @@ const CardGame = () => {
   const [setupForBothTeams, setSetupForBothTeams] = useState(false);
   const [isPowerupGuideOpen, setIsPowerupGuideOpen] = useState(false);
   const [setupMode, setSetupMode] = useState<SetupMode>('per-team');
+  const [historyStack, setHistoryStack] = useState<GameSnapshot[]>([]);
+  const shouldGuardNavigation = gameState === 'gamePlaying';
+
+  useNavigationGuard(shouldGuardNavigation, t('game.navigationWarning'));
+
+  const recordHistorySnapshot = useCallback(() => {
+    setHistoryStack((prev) =>
+      pushGameSnapshot(
+        prev,
+        createGameSnapshot({
+          team1Data,
+          team2Data,
+          duelData,
+          teamWinner,
+          duelResult,
+          isFirstTurn,
+          gameState,
+          roundNumber,
+          winStreaks
+        })
+      )
+    );
+  }, [
+    team1Data,
+    team2Data,
+    duelData,
+    teamWinner,
+    duelResult,
+    isFirstTurn,
+    gameState,
+    roundNumber,
+    winStreaks
+  ]);
+
+  const undoLastAction = useCallback(() => {
+    const snapshot = historyStack[historyStack.length - 1];
+    if (!snapshot) return;
+
+    setHistoryStack((prev) => prev.slice(0, -1));
+    setTeam1Data(snapshot.team1Data);
+    setTeam2Data(snapshot.team2Data);
+    setDuelData(snapshot.duelData);
+    setTeamWinner(snapshot.teamWinner);
+    setDuelResult(snapshot.duelResult);
+    setIsFirstTurn(snapshot.isFirstTurn);
+    setGameState(snapshot.gameState);
+    setRoundNumber(snapshot.roundNumber);
+    setWinStreaks(snapshot.winStreaks);
+    setConfirmPopup({
+      isVisible: false,
+      teamName: undefined,
+      chanceType: undefined,
+      chanceItemName: ''
+    });
+    setShowWinnerAnnouncement(false);
+  }, [historyStack]);
+
+  const canUndo = historyStack.length > 0;
 
   /**
    * Starts the game with the provided team data
@@ -154,11 +218,12 @@ const CardGame = () => {
       return;
     }
 
+    setHistoryStack([]);
     setWinStreaks({});
     setGameState('gamePlaying');
     // setTotalRound(Math.max(team1Data.length, team2Data.length));
     // Start the first round
-    nextRound(team1Data, team2Data);
+    nextRound(team1Data, team2Data, false);
   };
 
   /**
@@ -219,7 +284,15 @@ const CardGame = () => {
 
   // Function to select the next players for each team
   const nextRound = useCallback(
-    (inputTeam1: string[], inputTeam2: string[]) => {
+    (
+      inputTeam1: string[],
+      inputTeam2: string[],
+      shouldRecordHistory = true
+    ) => {
+      if (shouldRecordHistory) {
+        recordHistorySnapshot();
+      }
+
       if (inputTeam1.length === 0 || inputTeam2.length === 0) {
         setTeamWinner(
           inputTeam1.length === 0
@@ -278,10 +351,12 @@ const CardGame = () => {
       setDuelResult(''); // Clear previous duel result
       setRoundNumber((prev) => prev + 1);
     },
-    [roundNumber, t]
+    [recordHistorySnapshot, roundNumber, t]
   );
 
   const playerSelect = (side: Side) => {
+    recordHistorySnapshot();
+
     const currentPlayer = duelData.currentPlayerName; // Capture current player before any updates
     const newDuelIndex = duelData.duelIndex + 1;
     setIsFirstTurn(false);
@@ -710,6 +785,8 @@ const CardGame = () => {
     const { teamName, chanceType } = confirmPopup;
 
     if (teamName && chanceType) {
+      recordHistorySnapshot();
+
       switch (chanceType) {
         case 'secondChance': {
           if (teamName === 'team1') {
@@ -2125,10 +2202,18 @@ const CardGame = () => {
           nextRound={nextRound}
           onChanceClick={handleChanceClick}
           duelEquity={duelEquity}
+          canUndo={canUndo}
+          onUndo={undoLastAction}
         />
       )}
 
-      {gameState == 'gameOver' && <GameOverScreen teamWinner={teamWinner} />}
+      {gameState == 'gameOver' && (
+        <GameOverScreen
+          teamWinner={teamWinner}
+          canUndo={canUndo}
+          onUndo={undoLastAction}
+        />
+      )}
 
       <WinnerAnnouncement
         show={showWinnerAnnouncement}

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -33,7 +33,8 @@ import {
 } from '~/features/game/state/initialState';
 import {
   createGameSnapshot,
-  pushGameSnapshot
+  pushGameSnapshot,
+  shouldRecordGameSnapshot
 } from '~/features/game/state/historyStack';
 import type { GameSnapshot } from '~/features/game/state/historyStack';
 import {
@@ -148,12 +149,15 @@ const CardGame = () => {
   const [setupForBothTeams, setSetupForBothTeams] = useState(false);
   const [isPowerupGuideOpen, setIsPowerupGuideOpen] = useState(false);
   const [setupMode, setSetupMode] = useState<SetupMode>('per-team');
+  const [undoEnabled, setUndoEnabled] = useState(false);
   const [historyStack, setHistoryStack] = useState<GameSnapshot[]>([]);
   const shouldGuardNavigation = gameState === 'gamePlaying';
 
   useNavigationGuard(shouldGuardNavigation, t('game.navigationWarning'));
 
   const recordHistorySnapshot = useCallback(() => {
+    if (!shouldRecordGameSnapshot(undoEnabled, gameState)) return;
+
     setHistoryStack((prev) =>
       pushGameSnapshot(
         prev,
@@ -179,7 +183,8 @@ const CardGame = () => {
     isFirstTurn,
     gameState,
     roundNumber,
-    winStreaks
+    winStreaks,
+    undoEnabled
   ]);
 
   const undoLastAction = useCallback(() => {
@@ -205,7 +210,7 @@ const CardGame = () => {
     setShowWinnerAnnouncement(false);
   }, [historyStack]);
 
-  const canUndo = historyStack.length > 0;
+  const canUndo = undoEnabled && historyStack.length > 0;
 
   /**
    * Starts the game with the provided team data
@@ -1416,6 +1421,63 @@ const CardGame = () => {
                         {t('game.randomBoth')}
                       </label>
                     </div>
+                  </div>
+                  <div
+                    className="rpg-panel"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 20,
+                      marginTop: 6,
+                      marginBottom: 15,
+                      padding: '16px 20px',
+                      background: 'rgba(15, 12, 41, 0.8)',
+                      border: '2px solid var(--color-accent)'
+                    }}
+                  >
+                    <label
+                      htmlFor="enable-undo"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 12,
+                        fontFamily: 'var(--font-body)',
+                        fontSize: '1.1rem',
+                        cursor: 'pointer',
+                        color: undoEnabled ? 'var(--color-accent)' : '#fff'
+                      }}
+                    >
+                      <input
+                        id="enable-undo"
+                        type="checkbox"
+                        checked={undoEnabled}
+                        onChange={(event) => {
+                          const isEnabled = event.target.checked;
+                          setUndoEnabled(isEnabled);
+                          if (!isEnabled) {
+                            setHistoryStack([]);
+                          }
+                        }}
+                        style={{
+                          width: '20px',
+                          height: '20px',
+                          accentColor: 'var(--color-accent)',
+                          cursor: 'pointer'
+                        }}
+                      />
+                      {t('game.enableUndo')}
+                    </label>
+                    <span
+                      style={{
+                        color: '#ccc',
+                        fontFamily: 'var(--font-body)',
+                        fontSize: '0.95rem',
+                        textAlign: 'right'
+                      }}
+                    >
+                      {t('game.enableUndoHint')}
+                    </span>
                   </div>
                   <div
                     className="setup-grid"

--- a/app/utils/hooks/useNavigationGuard.ts
+++ b/app/utils/hooks/useNavigationGuard.ts
@@ -1,0 +1,26 @@
+import {
+  unstable_usePrompt as usePrompt,
+  useBeforeUnload
+} from '@remix-run/react';
+import { useCallback } from 'react';
+
+function useNavigationGuard(enabled: boolean, message: string) {
+  useBeforeUnload(
+    useCallback(
+      (event: BeforeUnloadEvent) => {
+        if (!enabled) return;
+
+        event.preventDefault();
+        event.returnValue = message;
+      },
+      [enabled, message]
+    )
+  );
+
+  usePrompt({
+    when: enabled,
+    message
+  });
+}
+
+export default useNavigationGuard;


### PR DESCRIPTION
## Summary
- Added an in-memory snapshot history stack for active matches, with Undo support for card selections, confirmed power-ups, next-round transitions, and game-over transitions.
- Threaded Undo controls through the arena and game-over screens, and reset history when a new game starts.
- Added localized Undo labels in English and Vietnamese.

## Testing
- Added focused unit tests for snapshot creation, stack capping, and immutability of stored snapshots.
- `npm run typecheck` passed.
- `npm run build` passed.
- `npm test` still reports the existing unrelated `equityEngine.test.ts` failures.
- `npm run lint` still reports the existing unrelated unused-variable errors in `app/features/game/engine/equityEngine.ts`.