### PR TITLE
Add redo stack support to game history flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,127 @@
-# Welcome to Remix!
+# Thor's 3Key
 
-- [Remix Docs](https://remix.run/docs)
+Thor's 3Key is a Remix web game for chaotic two-team card duels. Players are loaded from Google Sheets, each team allocates limited power-ups, and every round resolves a head-to-head card choice with theme-specific visuals, localized UI, undo/redo support, and duel equity feedback.
+
+## Tech Stack
+
+- **Runtime:** Node.js 20+
+- **Framework:** Remix 2 with the Vite compiler
+- **UI:** React 18, Remix routes, CSS in `app/app.css`
+- **Language:** TypeScript
+- **Testing:** Vitest
+- **Linting and formatting:** ESLint, Prettier
+- **Data source:** Google Sheets API via browser `fetch`
+- **Assets:** Static card, power-up, theme, favicon, and PWA manifest files in `public/`
+
+## Architecture
+
+```text
+app/
+  root.tsx                    Remix document shell, metadata, env loader, providers
+  routes/
+    _index.tsx                Landing page and share entry point
+    game.tsx                  Main game controller and route-level orchestration
+    robots.txt.ts             SEO route
+    sitemap.xml.ts            SEO route
+  contexts/
+    LanguageContext.tsx       English/Vietnamese translation state
+    ThemeContext.tsx          Theme state and persistence
+  components/                 Shared UI used across routes
+  features/game/
+    components/               Game-specific screens and display components
+    engine/                   Pure game rules: duels, equity, power-ups, allocation
+    services/                 External and asset services
+    state/                    Initial state and undo/redo history stack
+    types/                    Feature-level TypeScript types
+  models/                     Core data shapes used by game state
+  utils/                      Card utilities and reusable hooks
+public/
+  images/                     Card faces, backs, power-up icons, scene imagery
+  manifest.webmanifest        PWA metadata
+docs/
+  superpowers/                Design specs and implementation plans
+```
+
+### Request and State Flow
+
+```text
+Browser
+  -> Remix root loader
+       exposes API_KEY, SITE_URL, analytics, and social metadata
+  -> LanguageProvider + ThemeProvider
+  -> /game route
+       preloads card/theme assets
+       loads team names from Google Sheets
+       initializes team, duel, power-up, and history state
+       renders setup, arena, or game-over screens
+  -> game engines
+       calculate legal selections, power-up effects, duel winners, and equity
+  -> UI components
+       render cards, rounds, announcements, modals, share controls, and themes
+```
+
+`app/routes/game.tsx` owns the high-level game lifecycle and React state transitions. The reusable rules live in `app/features/game/engine`, so the logic can be tested without rendering the route. Services isolate I/O concerns such as Google Sheets loading and image preloading, while `state` modules create initial domain data and manage undo/redo snapshots.
+
+## Key Modules
+
+- `app/features/game/engine/duelEngine.ts` handles side selection and duel data lookup.
+- `app/features/game/engine/powerupEngine.ts` applies power-up behavior such as reveal, shield, second chance, and remove-worst logic.
+- `app/features/game/engine/equityEngine.ts` estimates duel win rates from known and unknown cards.
+- `app/features/game/state/historyStack.ts` stores undo/redo snapshots for in-progress games.
+- `app/features/game/services/sheetService.ts` loads and shuffles team rosters from Google Sheets.
+- `app/utils/gameUtil.ts` builds decks, shuffles, draws cards, compares hands, and resolves winners.
+- `app/contexts/LanguageContext.tsx` and `app/locales/*.ts` provide English and Vietnamese text.
+- `app/contexts/ThemeContext.tsx` drives visual theme selection and persistence.
+
+## Environment
+
+Create a local `.env` file when using Google Sheets or production metadata:
+
+```sh
+API_KEY=your_google_sheets_api_key
+SITE_URL=http://localhost:5173
+PLAUSIBLE_DOMAIN=
+TWITTER_HANDLE=thor3key
+```
+
+`API_KEY` is read by the Remix root loader and passed to the game route through outlet context. The game route uses it to call the Google Sheets API with the configured sheet ID and range.
 
 ## Development
 
-From your terminal:
+Install dependencies:
+
+```sh
+npm install
+```
+
+Start the Vite development server:
 
 ```sh
 npm run dev
 ```
 
-This starts your app in development mode, rebuilding assets on file changes.
-
-## Deployment
-
-First, build your app for production:
+Build for production:
 
 ```sh
 npm run build
 ```
 
-Then run the app in production mode:
+Run the production server:
 
 ```sh
 npm start
 ```
 
-Now you'll need to pick a host to deploy it to.
+Run checks:
 
-### DIY
+```sh
+npm run typecheck
+npm run lint
+npm test
+```
 
-If you're familiar with deploying node applications, the built-in Remix app server is production-ready.
+If the default dev port is already in use:
 
-Make sure to deploy the output of `remix build`
-
-- `build/server`
-- `build/client`
-
-### Commands
-
-`npx kill-port 5173`
+```sh
+npx kill-port 5173
+```

--- a/app/components/RoundStatus.tsx
+++ b/app/components/RoundStatus.tsx
@@ -26,6 +26,8 @@ interface RoundStatusProps {
   ) => void;
   canUndo: boolean;
   onUndo: () => void;
+  canRedo: boolean;
+  onRedo: () => void;
 }
 
 const RoundStatus: React.FC<RoundStatusProps> = ({
@@ -42,7 +44,9 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
   nextRound,
   onChanceClick,
   canUndo,
-  onUndo
+  onUndo,
+  canRedo,
+  onRedo
 }) => {
   const { t } = useLanguage();
 
@@ -427,19 +431,34 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
         )}
 
         <div style={{ marginTop: '12px' }}>
-          <button
-            onClick={onUndo}
-            disabled={!canUndo}
-            className="rpg-button secondary"
-            style={{
-              fontSize: '16px',
-              padding: '8px 28px',
-              opacity: canUndo ? 1 : 0.45,
-              cursor: canUndo ? 'pointer' : 'not-allowed'
-            }}
-          >
-            {t('game.undo')}
-          </button>
+          <div style={{ display: 'flex', gap: 10, justifyContent: 'center' }}>
+            <button
+              onClick={onUndo}
+              disabled={!canUndo}
+              className="rpg-button secondary"
+              style={{
+                fontSize: '16px',
+                padding: '8px 28px',
+                opacity: canUndo ? 1 : 0.45,
+                cursor: canUndo ? 'pointer' : 'not-allowed'
+              }}
+            >
+              {t('game.undo')}
+            </button>
+            <button
+              onClick={onRedo}
+              disabled={!canRedo}
+              className="rpg-button secondary"
+              style={{
+                fontSize: '16px',
+                padding: '8px 28px',
+                opacity: canRedo ? 1 : 0.45,
+                cursor: canRedo ? 'pointer' : 'not-allowed'
+              }}
+            >
+              {t('game.redo')}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -38,6 +38,8 @@ type GameArenaScreenProps = {
   duelEquity: DuelEquity | null;
   canUndo: boolean;
   onUndo: () => void;
+  canRedo: boolean;
+  onRedo: () => void;
 };
 
 const GameArenaScreen = ({
@@ -54,7 +56,9 @@ const GameArenaScreen = ({
   onChanceClick,
   duelEquity,
   canUndo,
-  onUndo
+  onUndo,
+  canRedo,
+  onRedo
 }: GameArenaScreenProps) => {
   const { t } = useLanguage();
   const player1EquityName = duelData.player1Name;
@@ -384,6 +388,8 @@ const GameArenaScreen = ({
         onChanceClick={onChanceClick}
         canUndo={canUndo}
         onUndo={onUndo}
+        canRedo={canRedo}
+        onRedo={onRedo}
       />
     </>
   );

--- a/app/features/game/components/GameOverScreen.tsx
+++ b/app/features/game/components/GameOverScreen.tsx
@@ -4,12 +4,16 @@ type GameOverScreenProps = {
   teamWinner: string;
   canUndo: boolean;
   onUndo: () => void;
+  canRedo: boolean;
+  onRedo: () => void;
 };
 
 const GameOverScreen = ({
   teamWinner,
   canUndo,
-  onUndo
+  onUndo,
+  canRedo,
+  onRedo
 }: GameOverScreenProps) => {
   const { t } = useLanguage();
   return (
@@ -72,20 +76,41 @@ const GameOverScreen = ({
             }}
           />
         </div>
-        <button
-          onClick={onUndo}
-          disabled={!canUndo}
-          className="rpg-button secondary"
+        <div
           style={{
             marginTop: '24px',
-            fontSize: '18px',
-            padding: '10px 36px',
-            opacity: canUndo ? 1 : 0.45,
-            cursor: canUndo ? 'pointer' : 'not-allowed'
+            display: 'flex',
+            gap: '12px',
+            justifyContent: 'center'
           }}
         >
-          {t('game.undo')}
-        </button>
+          <button
+            onClick={onUndo}
+            disabled={!canUndo}
+            className="rpg-button secondary"
+            style={{
+              fontSize: '18px',
+              padding: '10px 36px',
+              opacity: canUndo ? 1 : 0.45,
+              cursor: canUndo ? 'pointer' : 'not-allowed'
+            }}
+          >
+            {t('game.undo')}
+          </button>
+          <button
+            onClick={onRedo}
+            disabled={!canRedo}
+            className="rpg-button secondary"
+            style={{
+              fontSize: '18px',
+              padding: '10px 36px',
+              opacity: canRedo ? 1 : 0.45,
+              cursor: canRedo ? 'pointer' : 'not-allowed'
+            }}
+          >
+            {t('game.redo')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/app/features/game/state/historyStack.ts
+++ b/app/features/game/state/historyStack.ts
@@ -17,6 +17,24 @@ export type GameSnapshot = {
 };
 
 export type GameSnapshotInput = GameSnapshot;
+export type GameHistoryTransition = {
+  snapshotToApply?: GameSnapshot;
+  nextHistoryStack: GameSnapshot[];
+  nextRedoStack: GameSnapshot[];
+};
+type UndoTransitionInput = {
+  historyStack: GameSnapshot[];
+  redoStack: GameSnapshot[];
+  currentSnapshot: GameSnapshot;
+  trackRedo?: boolean;
+  limit?: number;
+};
+type RedoTransitionInput = {
+  historyStack: GameSnapshot[];
+  redoStack: GameSnapshot[];
+  currentSnapshot: GameSnapshot;
+  limit?: number;
+};
 
 const clone = <T>(value: T): T => structuredClone(value);
 
@@ -49,3 +67,50 @@ export const shouldRecordGameSnapshot = (
   undoEnabled: boolean,
   gameState: GameState
 ): boolean => undoEnabled && gameState === 'gamePlaying';
+
+export const createUndoTransition = ({
+  historyStack,
+  redoStack,
+  currentSnapshot,
+  trackRedo = true,
+  limit = HISTORY_STACK_LIMIT
+}: UndoTransitionInput): GameHistoryTransition => {
+  const snapshotToApply = historyStack[historyStack.length - 1];
+  if (!snapshotToApply) {
+    return {
+      snapshotToApply: undefined,
+      nextHistoryStack: historyStack,
+      nextRedoStack: redoStack
+    };
+  }
+
+  return {
+    snapshotToApply,
+    nextHistoryStack: historyStack.slice(0, -1),
+    nextRedoStack: trackRedo
+      ? pushGameSnapshot(redoStack, currentSnapshot, limit)
+      : redoStack
+  };
+};
+
+export const createRedoTransition = ({
+  historyStack,
+  redoStack,
+  currentSnapshot,
+  limit = HISTORY_STACK_LIMIT
+}: RedoTransitionInput): GameHistoryTransition => {
+  const snapshotToApply = redoStack[redoStack.length - 1];
+  if (!snapshotToApply) {
+    return {
+      snapshotToApply: undefined,
+      nextHistoryStack: historyStack,
+      nextRedoStack: redoStack
+    };
+  }
+
+  return {
+    snapshotToApply,
+    nextHistoryStack: pushGameSnapshot(historyStack, currentSnapshot, limit),
+    nextRedoStack: redoStack.slice(0, -1)
+  };
+};

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -55,7 +55,10 @@ export default {
     anonymous: 'ANONYMOUS',
     enableUndo: 'Enable Host Undo',
     enableUndoHint: 'Lets the host reverse gameplay mistakes during this match.',
+    enableRedo: 'Enable Host Redo',
+    enableRedoHint: 'Lets the host re-apply the most recently undone action.',
     undo: 'UNDO',
+    redo: 'REDO',
     navigationWarning:
       'A game is in progress. Leaving now will lose the current game. Continue?'
   },

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -55,7 +55,10 @@ export default {
     anonymous: 'Kẻ thế thân',
     enableUndo: 'Bật hoàn tác cho chủ trò',
     enableUndoHint: 'Cho phép chủ trò sửa lỗi bấm nhầm trong ván này.',
+    enableRedo: 'Bật làm lại cho chủ trò',
+    enableRedoHint: 'Cho phép chủ trò làm lại thao tác vừa hoàn tác.',
     undo: 'HOÀN TÁC',
+    redo: 'LÀM LẠI',
     navigationWarning:
       'Trận đang diễn ra. Rời trang bây giờ sẽ mất ván hiện tại. Tiếp tục?'
   },

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -33,6 +33,8 @@ import {
 } from '~/features/game/state/initialState';
 import {
   createGameSnapshot,
+  createRedoTransition,
+  createUndoTransition,
   pushGameSnapshot,
   shouldRecordGameSnapshot
 } from '~/features/game/state/historyStack';
@@ -150,48 +152,39 @@ const CardGame = () => {
   const [isPowerupGuideOpen, setIsPowerupGuideOpen] = useState(false);
   const [setupMode, setSetupMode] = useState<SetupMode>('per-team');
   const [undoEnabled, setUndoEnabled] = useState(false);
+  const [redoEnabled, setRedoEnabled] = useState(false);
   const [historyStack, setHistoryStack] = useState<GameSnapshot[]>([]);
+  const [redoStack, setRedoStack] = useState<GameSnapshot[]>([]);
   const shouldGuardNavigation = gameState === 'gamePlaying';
 
   useNavigationGuard(shouldGuardNavigation, t('game.navigationWarning'));
+  const createCurrentSnapshot = useCallback(
+    () =>
+      createGameSnapshot({
+        team1Data,
+        team2Data,
+        duelData,
+        teamWinner,
+        duelResult,
+        isFirstTurn,
+        gameState,
+        roundNumber,
+        winStreaks
+      }),
+    [
+      team1Data,
+      team2Data,
+      duelData,
+      teamWinner,
+      duelResult,
+      isFirstTurn,
+      gameState,
+      roundNumber,
+      winStreaks
+    ]
+  );
 
-  const recordHistorySnapshot = useCallback(() => {
-    if (!shouldRecordGameSnapshot(undoEnabled, gameState)) return;
-
-    setHistoryStack((prev) =>
-      pushGameSnapshot(
-        prev,
-        createGameSnapshot({
-          team1Data,
-          team2Data,
-          duelData,
-          teamWinner,
-          duelResult,
-          isFirstTurn,
-          gameState,
-          roundNumber,
-          winStreaks
-        })
-      )
-    );
-  }, [
-    team1Data,
-    team2Data,
-    duelData,
-    teamWinner,
-    duelResult,
-    isFirstTurn,
-    gameState,
-    roundNumber,
-    winStreaks,
-    undoEnabled
-  ]);
-
-  const undoLastAction = useCallback(() => {
-    const snapshot = historyStack[historyStack.length - 1];
-    if (!snapshot) return;
-
-    setHistoryStack((prev) => prev.slice(0, -1));
+  const applyGameSnapshot = useCallback((snapshot: GameSnapshot) => {
     setTeam1Data(snapshot.team1Data);
     setTeam2Data(snapshot.team2Data);
     setDuelData(snapshot.duelData);
@@ -208,9 +201,68 @@ const CardGame = () => {
       chanceItemName: ''
     });
     setShowWinnerAnnouncement(false);
-  }, [historyStack]);
+  }, []);
+
+  const recordHistorySnapshot = useCallback(() => {
+    if (!shouldRecordGameSnapshot(undoEnabled, gameState)) return;
+
+    setHistoryStack((prev) =>
+      pushGameSnapshot(prev, createCurrentSnapshot())
+    );
+    setRedoStack([]);
+  }, [
+    createCurrentSnapshot,
+    gameState,
+    undoEnabled
+  ]);
+
+  const undoLastAction = useCallback(() => {
+    if (!undoEnabled) return;
+
+    const transition = createUndoTransition({
+      historyStack,
+      redoStack,
+      currentSnapshot: createCurrentSnapshot(),
+      trackRedo: redoEnabled
+    });
+    if (!transition.snapshotToApply) return;
+
+    setHistoryStack(transition.nextHistoryStack);
+    setRedoStack(transition.nextRedoStack);
+    applyGameSnapshot(transition.snapshotToApply);
+  }, [
+    applyGameSnapshot,
+    createCurrentSnapshot,
+    historyStack,
+    redoEnabled,
+    redoStack,
+    undoEnabled
+  ]);
+
+  const redoLastAction = useCallback(() => {
+    if (!undoEnabled || !redoEnabled) return;
+
+    const transition = createRedoTransition({
+      historyStack,
+      redoStack,
+      currentSnapshot: createCurrentSnapshot()
+    });
+    if (!transition.snapshotToApply) return;
+
+    setHistoryStack(transition.nextHistoryStack);
+    setRedoStack(transition.nextRedoStack);
+    applyGameSnapshot(transition.snapshotToApply);
+  }, [
+    applyGameSnapshot,
+    createCurrentSnapshot,
+    historyStack,
+    redoEnabled,
+    redoStack,
+    undoEnabled
+  ]);
 
   const canUndo = undoEnabled && historyStack.length > 0;
+  const canRedo = undoEnabled && redoEnabled && redoStack.length > 0;
 
   /**
    * Starts the game with the provided team data
@@ -224,6 +276,7 @@ const CardGame = () => {
     }
 
     setHistoryStack([]);
+    setRedoStack([]);
     setWinStreaks({});
     setGameState('gamePlaying');
     // setTotalRound(Math.max(team1Data.length, team2Data.length));
@@ -1426,7 +1479,7 @@ const CardGame = () => {
                     className="rpg-panel"
                     style={{
                       display: 'flex',
-                      alignItems: 'center',
+                      alignItems: 'flex-start',
                       justifyContent: 'space-between',
                       gap: 20,
                       marginTop: 6,
@@ -1436,48 +1489,115 @@ const CardGame = () => {
                       border: '2px solid var(--color-accent)'
                     }}
                   >
-                    <label
-                      htmlFor="enable-undo"
+                    <div
                       style={{
                         display: 'flex',
-                        alignItems: 'center',
-                        gap: 12,
-                        fontFamily: 'var(--font-body)',
-                        fontSize: '1.1rem',
-                        cursor: 'pointer',
-                        color: undoEnabled ? 'var(--color-accent)' : '#fff'
+                        flexDirection: 'column',
+                        gap: 12
                       }}
                     >
-                      <input
-                        id="enable-undo"
-                        type="checkbox"
-                        checked={undoEnabled}
-                        onChange={(event) => {
-                          const isEnabled = event.target.checked;
-                          setUndoEnabled(isEnabled);
-                          if (!isEnabled) {
-                            setHistoryStack([]);
-                          }
-                        }}
+                      <label
+                        htmlFor="enable-undo"
                         style={{
-                          width: '20px',
-                          height: '20px',
-                          accentColor: 'var(--color-accent)',
-                          cursor: 'pointer'
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 12,
+                          fontFamily: 'var(--font-body)',
+                          fontSize: '1.1rem',
+                          cursor: 'pointer',
+                          color: undoEnabled ? 'var(--color-accent)' : '#fff'
                         }}
-                      />
-                      {t('game.enableUndo')}
-                    </label>
-                    <span
+                      >
+                        <input
+                          id="enable-undo"
+                          type="checkbox"
+                          checked={undoEnabled}
+                          onChange={(event) => {
+                            const isEnabled = event.target.checked;
+                            setUndoEnabled(isEnabled);
+                            if (!isEnabled) {
+                              setRedoEnabled(false);
+                              setHistoryStack([]);
+                              setRedoStack([]);
+                            }
+                          }}
+                          style={{
+                            width: '20px',
+                            height: '20px',
+                            accentColor: 'var(--color-accent)',
+                            cursor: 'pointer'
+                          }}
+                        />
+                        {t('game.enableUndo')}
+                      </label>
+                      <label
+                        htmlFor="enable-redo"
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 12,
+                          fontFamily: 'var(--font-body)',
+                          fontSize: '1.1rem',
+                          cursor: undoEnabled ? 'pointer' : 'not-allowed',
+                          color:
+                            undoEnabled && redoEnabled
+                              ? 'var(--color-accent)'
+                              : '#fff',
+                          opacity: undoEnabled ? 1 : 0.55
+                        }}
+                      >
+                        <input
+                          id="enable-redo"
+                          type="checkbox"
+                          checked={redoEnabled}
+                          disabled={!undoEnabled}
+                          onChange={(event) => {
+                            const isEnabled = event.target.checked;
+                            setRedoEnabled(isEnabled);
+                            if (!isEnabled) {
+                              setRedoStack([]);
+                            }
+                          }}
+                          style={{
+                            width: '20px',
+                            height: '20px',
+                            accentColor: 'var(--color-accent)',
+                            cursor: undoEnabled ? 'pointer' : 'not-allowed'
+                          }}
+                        />
+                        {t('game.enableRedo')}
+                      </label>
+                    </div>
+                    <div
                       style={{
-                        color: '#ccc',
-                        fontFamily: 'var(--font-body)',
-                        fontSize: '0.95rem',
-                        textAlign: 'right'
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 8,
+                        alignItems: 'flex-end'
                       }}
                     >
-                      {t('game.enableUndoHint')}
-                    </span>
+                      <span
+                        style={{
+                          color: '#ccc',
+                          fontFamily: 'var(--font-body)',
+                          fontSize: '0.95rem',
+                          textAlign: 'right'
+                        }}
+                      >
+                        {t('game.enableUndoHint')}
+                      </span>
+                      <span
+                        style={{
+                          color: '#ccc',
+                          fontFamily: 'var(--font-body)',
+                          fontSize: '0.95rem',
+                          textAlign: 'right',
+                          opacity: undoEnabled ? 1 : 0.55
+                        }}
+                      >
+                        {t('game.enableRedoHint')}
+                      </span>
+                    </div>
                   </div>
                   <div
                     className="setup-grid"
@@ -2266,6 +2386,8 @@ const CardGame = () => {
           duelEquity={duelEquity}
           canUndo={canUndo}
           onUndo={undoLastAction}
+          canRedo={canRedo}
+          onRedo={redoLastAction}
         />
       )}
 
@@ -2274,6 +2396,8 @@ const CardGame = () => {
           teamWinner={teamWinner}
           canUndo={canUndo}
           onUndo={undoLastAction}
+          canRedo={canRedo}
+          onRedo={redoLastAction}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Introduce a dedicated history stack for redo-aware game state transitions.
- Update the game arena and game over flows to use the revised stack behavior.
- Refresh round status copy and localized strings in English and Vietnamese.
- Wire the game route to the updated history handling.

## Testing
- Not run (not requested)