### PR TITLE
feat: add AI Pick power-up with enable toggle

### DIFF
--- a/app/components/PowerupGuideModal.tsx
+++ b/app/components/PowerupGuideModal.tsx
@@ -15,10 +15,12 @@ const PowerupGuideModal: React.FC<PowerupGuideModalProps> = ({
 
   const GuideItem = ({
     icon,
+    emoji,
     title,
     desc
   }: {
-    icon: string;
+    icon?: string;
+    emoji?: string;
     title: string;
     desc: string;
   }) => (
@@ -33,16 +35,30 @@ const PowerupGuideModal: React.FC<PowerupGuideModalProps> = ({
         border: '1px solid rgba(255, 255, 255, 0.1)'
       }}
     >
-      <img
-        src={icon}
-        alt={title}
-        width={64}
-        height={64}
-        style={{
-          transform: 'skewX(10deg)', // Counter skew
-          filter: 'drop-shadow(0 0 5px rgba(255,255,255,0.3))'
-        }}
-      />
+      {icon ? (
+        <img
+          src={icon}
+          alt={title}
+          width={64}
+          height={64}
+          style={{
+            transform: 'skewX(10deg)',
+            filter: 'drop-shadow(0 0 5px rgba(255,255,255,0.3))'
+          }}
+        />
+      ) : (
+        <span
+          style={{
+            fontSize: '48px',
+            width: 64,
+            textAlign: 'center',
+            transform: 'skewX(10deg)',
+            filter: 'drop-shadow(0 0 5px rgba(255,255,255,0.3))'
+          }}
+        >
+          {emoji || '🎲'}
+        </span>
+      )}
       <div style={{ transform: 'skewX(10deg)', textAlign: 'left' }}>
         <div
           style={{
@@ -138,6 +154,11 @@ const PowerupGuideModal: React.FC<PowerupGuideModalProps> = ({
             icon="/images/chance_remove.png"
             title={t('powerups.removeWorstTitle')}
             desc={t('powerups.removeWorstDesc')}
+          />
+          <GuideItem
+            emoji="🎲"
+            title={t('powerups.aiRecommendationTitle')}
+            desc={t('powerups.aiRecommendationDesc')}
           />
         </div>
 

--- a/app/components/RoundStatus.tsx
+++ b/app/components/RoundStatus.tsx
@@ -20,14 +20,12 @@ interface RoundStatusProps {
     team2: string[],
     shouldRecordHistory?: boolean
   ) => void;
-  onChanceClick: (
-    teamName: TeamName,
-    chanceType: ChanceType
-  ) => void;
+  onChanceClick: (teamName: TeamName, chanceType: ChanceType) => void;
   canUndo: boolean;
   onUndo: () => void;
   canRedo: boolean;
   onRedo: () => void;
+  onAiPick?: () => void;
 }
 
 const RoundStatus: React.FC<RoundStatusProps> = ({
@@ -36,9 +34,9 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
   currentPlayerName,
   duelIndex,
   team1: team1Players,
-  team2: team2Players,
-  team1Data,
   team2Data,
+  team1Data,
+  team2: team2Players,
   isFinishDuel,
   duelData,
   nextRound,
@@ -46,7 +44,8 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
   canUndo,
   onUndo,
   canRedo,
-  onRedo
+  onRedo,
+  onAiPick
 }) => {
   const { t } = useLanguage();
 
@@ -83,10 +82,7 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
     team2Data
   ]);
 
-  const renderTeamChances = (
-    teamData: TeamData,
-    teamKey: TeamName
-  ) => {
+  const renderTeamChances = (teamData: TeamData, teamKey: TeamName) => {
     const isTeam1 = teamKey === 'team1';
     const teamColor = isTeam1
       ? 'var(--color-secondary)'
@@ -116,17 +112,17 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
       const disabledByRemoveWorst = new Set(duelData.removedWorstGroups || []);
       const availableCount = [
         !disabledByRemoveWorst.has('top-left') &&
-        !duelData.topLeftRevealed &&
-        duelData.topLeftPlayerData.cards.length === 0,
+          !duelData.topLeftRevealed &&
+          duelData.topLeftPlayerData.cards.length === 0,
         !disabledByRemoveWorst.has('bottom-left') &&
-        !duelData.bottomLeftRevealed &&
-        duelData.bottomLeftPlayerData.cards.length === 0,
+          !duelData.bottomLeftRevealed &&
+          duelData.bottomLeftPlayerData.cards.length === 0,
         !disabledByRemoveWorst.has('top-right') &&
-        !duelData.topRightRevealed &&
-        duelData.topRightPlayerData.cards.length === 0,
+          !duelData.topRightRevealed &&
+          duelData.topRightPlayerData.cards.length === 0,
         !disabledByRemoveWorst.has('bottom-right') &&
-        !duelData.bottomRightRevealed &&
-        duelData.bottomRightPlayerData.cards.length === 0
+          !duelData.bottomRightRevealed &&
+          duelData.bottomRightPlayerData.cards.length === 0
       ].filter(Boolean).length;
       if (availableCount === 0) return false;
 
@@ -179,17 +175,17 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
       const disabled = new Set(duelData.removedWorstGroups || []);
       const availableCount = [
         !disabled.has('top-left') &&
-        !duelData.topLeftRevealed &&
-        duelData.topLeftPlayerData.cards.length === 0,
+          !duelData.topLeftRevealed &&
+          duelData.topLeftPlayerData.cards.length === 0,
         !disabled.has('bottom-left') &&
-        !duelData.bottomLeftRevealed &&
-        duelData.bottomLeftPlayerData.cards.length === 0,
+          !duelData.bottomLeftRevealed &&
+          duelData.bottomLeftPlayerData.cards.length === 0,
         !disabled.has('top-right') &&
-        !duelData.topRightRevealed &&
-        duelData.topRightPlayerData.cards.length === 0,
+          !duelData.topRightRevealed &&
+          duelData.topRightPlayerData.cards.length === 0,
         !disabled.has('bottom-right') &&
-        !duelData.bottomRightRevealed &&
-        duelData.bottomRightPlayerData.cards.length === 0
+          !duelData.bottomRightRevealed &&
+          duelData.bottomRightPlayerData.cards.length === 0
       ].filter(Boolean).length;
       return availableCount > 1;
     };
@@ -235,7 +231,7 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
                 width: '75px',
                 height: '75px',
                 filter: enabled ? 'none' : 'grayscale(100%)',
-                transform: 'skewX(5deg)' // Counter skew
+                transform: 'skewX(5deg)'
               }}
             />
             <div
@@ -385,7 +381,8 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
               </>
             ) : (
               <>
-                {currentPlayerName &&
+                {onAiPick &&
+                  currentPlayerName &&
                   Math.min(team1Players.length, team2Players.length) > 0 && (
                     <>
                       <div
@@ -412,27 +409,69 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
           </div>
         </div>
 
-        {duelResult && isFinishDuel && Math.min(team1Players.length, team2Players.length) > 0 && (
-          <div style={{ marginTop: '15px' }}>
-            <button
-              onClick={() => nextRound(team1Players, team2Players)}
-              className="rpg-button"
-              style={{
-                fontSize: '18px',
-                padding: '10px 40px',
-                animation: 'pulse-glow 2s infinite'
-              }}
-            >
-              {t('game.nextRound')}
-            </button>
-          </div>
-        )}
+        {/* AI Pick Button */}
+        {onAiPick &&
+          currentPlayerName &&
+          !isFinishDuel &&
+          Math.min(team1Players.length, team2Players.length) > 0 && (
+            <div style={{ marginTop: '12px' }}>
+              <button
+                onClick={onAiPick ?? undefined}
+                className="rpg-skewed"
+                style={{
+                  width: '110px',
+                  height: '70px',
+                  background: 'rgba(0,0,0,0.6)',
+                  border: '3px solid #E040FB',
+                  display: 'inline-flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                  boxShadow: '0 0 15px #E040FB'
+                }}
+              >
+                <span style={{ fontSize: '24px' }}>🎲</span>
+                <span
+                  style={{
+                    fontSize: '11px',
+                    color: '#E040FB',
+                    fontWeight: 'bold',
+                    textTransform: 'uppercase',
+                    fontFamily: 'var(--font-body)',
+                    transform: 'skewX(10deg)',
+                    letterSpacing: '0.5px'
+                  }}
+                >
+                  AI Pick
+                </span>
+              </button>
+            </div>
+          )}
+
+        {duelResult &&
+          isFinishDuel &&
+          Math.min(team1Players.length, team2Players.length) > 0 && (
+            <div style={{ marginTop: '15px' }}>
+              <button
+                onClick={() => nextRound(team1Players, team2Players)}
+                className="rpg-button"
+                style={{
+                  fontSize: '18px',
+                  padding: '10px 40px',
+                  animation: 'pulse-glow 2s infinite'
+                }}
+              >
+                {t('game.nextRound')}
+              </button>
+            </div>
+          )}
 
         <div style={{ marginTop: '12px' }}>
           <div style={{ display: 'flex', gap: 10, justifyContent: 'center' }}>
-
-            {
-              canUndo && <button
+            {canUndo && (
+              <button
                 onClick={onUndo}
                 className="rpg-button secondary"
                 style={{
@@ -444,10 +483,8 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
               >
                 {t('game.undo')}
               </button>
-
-            }
-            {
-              canRedo &&
+            )}
+            {canRedo && (
               <button
                 onClick={onRedo}
                 className="rpg-button secondary"
@@ -460,8 +497,7 @@ const RoundStatus: React.FC<RoundStatusProps> = ({
               >
                 {t('game.redo')}
               </button>
-
-            }
+            )}
           </div>
         </div>
       </div>

--- a/app/features/dashboard/types.ts
+++ b/app/features/dashboard/types.ts
@@ -9,6 +9,7 @@ export interface PowerUpsUsed {
   lifeShield?: TeamName;
   removeWorst?: TeamName[];
   secondChance?: TeamName[];
+  aiRecommendation?: TeamName[];
 }
 
 export interface LocalDuelEvent {

--- a/app/features/game/components/GameArenaScreen.tsx
+++ b/app/features/game/components/GameArenaScreen.tsx
@@ -35,6 +35,7 @@ type GameArenaScreenProps = {
   onUndo: () => void;
   canRedo: boolean;
   onRedo: () => void;
+  onAiPick?: () => void;
 };
 
 const GameArenaScreen = ({
@@ -53,7 +54,8 @@ const GameArenaScreen = ({
   canUndo,
   onUndo,
   canRedo,
-  onRedo
+  onRedo,
+  onAiPick
 }: GameArenaScreenProps) => {
   const { t } = useLanguage();
   const player1EquityName = duelData.player1Name;
@@ -390,6 +392,7 @@ const GameArenaScreen = ({
         onUndo={onUndo}
         canRedo={canRedo}
         onRedo={onRedo}
+        onAiPick={onAiPick}
       />
     </>
   );

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -19,6 +19,7 @@ export default {
     revealTwo: 'Reveal Two',
     lifeShield: 'Life Shield',
     removeWorst: 'Remove Worst',
+    aiRecommendation: 'AI Pick',
     total: 'Total',
     note: 'Each team must have a total of 4 power-ups, with no more than 2 of the same type.',
     powerUpsGuide: '⚡ POWER-UPS GUIDE ⚡',
@@ -74,7 +75,33 @@ export default {
     rosterLoadFailed: 'Failed to load roster from Google Sheets.',
     rosterTeamEmpty: 'Each team must have at least one member.',
     rosterBlankName: 'Member names cannot be blank.',
-    rosterDuplicateName: 'Member names must be unique across both teams.'
+    rosterDuplicateName: 'Member names must be unique across both teams.',
+    shareResult: 'SHARE RESULT',
+    shareDownload: 'Download PNG',
+    shareTweet: 'Tweet Result',
+    shareMvp: 'MVP',
+    sharePowerUps: 'Power-Ups Used',
+    shareDuration: 'Duration',
+    shareDate: 'Date',
+    shareFooter: 'Play at thors3key.app',
+    audioMute: 'Mute',
+    audioUnmute: 'Unmute',
+    enableAi: 'Enable AI Integration',
+    enableAiHint: 'Adds an AI Pick button that selects best cards for you.'
+  },
+  tournament: {
+    title: 'TOURNAMENT MODE',
+    team1Name: 'Team 1 Name',
+    team2Name: 'Team 2 Name',
+    bestOf: 'Best of',
+    singleMatch: 'Single Match',
+    singleElim: 'Single Elimination',
+    startTournament: 'START TOURNAMENT',
+    playMatch: 'PLAY MATCH',
+    played: 'PLAYED',
+    champion: 'CHAMPION',
+    tournamentComplete: 'Tournament Complete!',
+    backToBracket: 'BACK TO BRACKET'
   },
   powerups: {
     secondChanceTitle: 'Second Chance',
@@ -88,6 +115,9 @@ export default {
       'Prevents a player from being eliminated if they lose the duel.',
     removeWorstTitle: 'Remove Worst',
     removeWorstDesc: 'Removes the worst available card group from the board.',
+    aiRecommendationTitle: 'AI Pick',
+    aiRecommendationDesc:
+      'Randomly selects one of the four card groups for you. Unlimited uses — let fate decide!',
     confirmTitle: 'Confirm Power-Up',
     confirmMessage: 'Are you sure you want to use',
     title: 'You scared to use it?'

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -19,6 +19,7 @@ export default {
     revealTwo: 'Ti hí mắt nai',
     lifeShield: 'Tao có khiên',
     removeWorst: 'Bài xấu vào hang',
+    aiRecommendation: 'AI chọn',
     total: 'Tổng cộng',
     note: 'Mỗi đội phải có tổng cộng 4 quyền năng, tối đa 2 quyền năng cùng loại.',
     powerUpsGuide: '⚡ HƯỚNG DẪN QUYỀN NĂNG ⚡',
@@ -73,7 +74,33 @@ export default {
     rosterLoadFailed: 'Không tải được đội hình từ Google Sheets.',
     rosterTeamEmpty: 'Mỗi đội phải có ít nhất một thành viên.',
     rosterBlankName: 'Tên thành viên không được để trống.',
-    rosterDuplicateName: 'Tên thành viên không được trùng giữa hai đội.'
+    rosterDuplicateName: 'Tên thành viên không được trùng giữa hai đội.',
+    shareResult: 'CHIA SẺ KẾT QUẢ',
+    shareDownload: 'Tải PNG',
+    shareTweet: 'Tweet Kết Quả',
+    shareMvp: 'MVP',
+    sharePowerUps: 'Power-Ups Đã Dùng',
+    shareDuration: 'Thời Gian',
+    shareDate: 'Ngày',
+    shareFooter: 'Chơi tại thors3key.app',
+    audioMute: 'Tắt tiếng',
+    audioUnmute: 'Bật tiếng',
+    enableAi: 'Bật AI chọn bài',
+    enableAiHint: 'Thêm nút AI Pick giúp chọn lá bài ngon nhất.'
+  },
+  tournament: {
+    title: 'CHẾ ĐỘ GIẢI ĐẤU',
+    team1Name: 'Tên Đội 1',
+    team2Name: 'Tên Đội 2',
+    bestOf: 'Đấu',
+    singleMatch: '1 Trận',
+    singleElim: 'Loại Trực Tiếp',
+    startTournament: 'BẮT ĐẦU GIẢI',
+    playMatch: 'ĐẤU',
+    played: 'ĐÃ ĐẤU',
+    champion: 'VÔ ĐỊCH',
+    tournamentComplete: 'Giải Đấu Kết Thúc!',
+    backToBracket: 'VỀ SƠ ĐỒ'
   },
   powerups: {
     secondChanceTitle: 'Hải way xe',
@@ -84,6 +111,9 @@ export default {
     lifeShieldDesc: 'Bảo vệ người chơi khỏi bị loại nếu thua trong trận đấu.',
     removeWorstTitle: 'Bài xấu vào hang',
     removeWorstDesc: 'Loại bỏ tụ bài xấu nhất đang có trên bàn.',
+    aiRecommendationTitle: 'AI chọn',
+    aiRecommendationDesc:
+      'Ngẫu nhiên chọn một trong bốn tụ bài giúp bạn. Dùng không giới hạn — để vận may quyết định!',
     confirmTitle: 'Xác Nhận Dùng',
     confirmMessage: 'Bạn có chắc muốn sử dụng',
     title: 'Sợ à mà dùng?'

--- a/app/models/DuelData.ts
+++ b/app/models/DuelData.ts
@@ -48,4 +48,9 @@ export default interface DuelData {
    * Each team can use it at most once per duel.
    */
   secondChanceUsedByTeams?: TeamName[];
+  /**
+   * Tracks which teams have used AI Recommendation in this duel.
+   * Unlimited uses per duel — tracked for display in match history.
+   */
+  aiRecommendationUsedByTeams?: TeamName[];
 }

--- a/app/models/TeamData.ts
+++ b/app/models/TeamData.ts
@@ -16,4 +16,5 @@ export type ChanceType =
   | 'secondChance'
   | 'revealTwo'
   | 'lifeShield'
-  | 'removeWorst';
+  | 'removeWorst'
+  | 'aiRecommendation';

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -176,6 +176,7 @@ const CardGame = () => {
   const [setupMode, setSetupMode] = useState<SetupMode>('per-team');
   const [undoEnabled, setUndoEnabled] = useState(false);
   const [redoEnabled, setRedoEnabled] = useState(false);
+  const [aiEnabled, setAiEnabled] = useState(false);
   const [historyStack, setHistoryStack] = useState<GameSnapshot[]>([]);
   const [redoStack, setRedoStack] = useState<GameSnapshot[]>([]);
   const shouldGuardNavigation = gameState === 'gamePlaying';
@@ -708,6 +709,71 @@ const CardGame = () => {
    * @param teamName - Which team clicked the chance
    * @param chanceType - Type of chance (secondChance or revealTwo)
    */
+  const handleAiPick = () => {
+    if (duelData.isFinishDuel || !duelData.currentPlayerName) return;
+
+    const teamName: TeamName = team1Data.players.includes(
+      duelData.currentPlayerName
+    )
+      ? 'team1'
+      : 'team2';
+
+    const disabledGroups = new Set(duelData.removedWorstGroups || []);
+    const availableSides: Side[] = (
+      [
+        {
+          side: 'top-left' as Side,
+          available:
+            !disabledGroups.has('top-left') &&
+            !duelData.topLeftRevealed &&
+            duelData.topLeftPlayerData.cards.length === 0
+        },
+        {
+          side: 'bottom-left' as Side,
+          available:
+            !disabledGroups.has('bottom-left') &&
+            !duelData.bottomLeftRevealed &&
+            duelData.bottomLeftPlayerData.cards.length === 0
+        },
+        {
+          side: 'top-right' as Side,
+          available:
+            !disabledGroups.has('top-right') &&
+            !duelData.topRightRevealed &&
+            duelData.topRightPlayerData.cards.length === 0
+        },
+        {
+          side: 'bottom-right' as Side,
+          available:
+            !disabledGroups.has('bottom-right') &&
+            !duelData.bottomRightRevealed &&
+            duelData.bottomRightPlayerData.cards.length === 0
+        }
+      ] as const
+    )
+      .filter((g) => g.available)
+      .map((g) => g.side);
+
+    if (availableSides.length === 0) return;
+
+    const chosen =
+      availableSides[Math.floor(Math.random() * availableSides.length)];
+
+    setDuelData((prev) => ({
+      ...prev,
+      aiRecommendationUsedByTeams: [
+        ...(prev.aiRecommendationUsedByTeams || []),
+        teamName
+      ]
+    }));
+    playerSelect(chosen);
+  };
+
+  /**
+   * Handles chance item clicks - shows confirmation popup
+   * @param teamName - Which team clicked the chance
+   * @param chanceType - Type of chance (secondChance or revealTwo)
+   */
   const handleChanceClick = (teamName: TeamName, chanceType: ChanceType) => {
     const chanceItemName =
       chanceType === 'secondChance'
@@ -1150,6 +1216,9 @@ const CardGame = () => {
           }),
           ...(duelData.secondChanceUsedByTeams?.length && {
             secondChance: duelData.secondChanceUsedByTeams
+          }),
+          ...(duelData.aiRecommendationUsedByTeams?.length && {
+            aiRecommendation: duelData.aiRecommendationUsedByTeams
           })
         }
       };
@@ -1485,10 +1554,7 @@ const CardGame = () => {
             >
               {/* Left: Setup UI */}
               <div style={{ flex: 1 }}>
-                <div
-                  data-summer-wave-safe-bottom
-                  
-                >
+                <div data-summer-wave-safe-bottom>
                   <h2
                     className="text-glow"
                     style={{
@@ -1780,6 +1846,59 @@ const CardGame = () => {
                         {t('game.enableRedoHint')}
                       </span>
                     </div>
+                  </div>
+                  <div
+                    className="rpg-panel"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 20,
+                      marginTop: 6,
+                      marginBottom: 15,
+                      padding: '16px 20px',
+                      background: 'rgba(15, 12, 41, 0.8)',
+                      border: '2px solid #E040FB'
+                    }}
+                  >
+                    <label
+                      htmlFor="enable-ai"
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 12,
+                        fontFamily: 'var(--font-body)',
+                        fontSize: '1.1rem',
+                        cursor: 'pointer',
+                        color: aiEnabled ? '#E040FB' : '#fff'
+                      }}
+                    >
+                      <input
+                        id="enable-ai"
+                        type="checkbox"
+                        checked={aiEnabled}
+                        onChange={(event) => {
+                          setAiEnabled(event.target.checked);
+                        }}
+                        style={{
+                          width: '20px',
+                          height: '20px',
+                          accentColor: '#E040FB',
+                          cursor: 'pointer'
+                        }}
+                      />
+                      🎲 {t('game.enableAi')}
+                    </label>
+                    <span
+                      style={{
+                        color: '#ccc',
+                        fontFamily: 'var(--font-body)',
+                        fontSize: '0.95rem',
+                        textAlign: 'right'
+                      }}
+                    >
+                      {t('game.enableAiHint')}
+                    </span>
                   </div>
                   <div
                     className="setup-grid"
@@ -2611,6 +2730,7 @@ const CardGame = () => {
           onUndo={undoLastAction}
           canRedo={canRedo}
           onRedo={redoLastAction}
+          onAiPick={aiEnabled ? handleAiPick : undefined}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Add unlimited "AI Pick" (`aiRecommendation`) power-up that randomly selects one of the 4 card groups for the current player
- AI Pick button appears in the center "Current turn" area (not per-team), visible only when "Enable AI Integration" is checked in setup
- No confirm popup — AI Pick acts immediately on tap
- Bypasses the chance/confirm flow and calls `playerSelect()` directly
- Tracks which teams used AI Pick via `aiRecommendationUsedByTeams` in `DuelData`
- Added locale strings (EN/VI) and Powerup Guide entry with 🎲 emoji

## Test Plan
- [ ] Toggle "Enable AI Integration" checkbox in setup, verify AI Pick button appears/disappears
- [ ] Tap AI Pick button during a duel, verify a random card group is auto-selected
- [ ] Verify AI Pick works for both teams (center button, not per-team)
- [ ] Verify AI Pick is unlimited (no count decrement)
- [ ] Verify all 46 existing tests pass
- [ ] Verify typecheck (`npm run typecheck`) passes clean