### PR TITLE
feat: add roster shuffle functionality

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -1079,6 +1079,17 @@ input[type='text']:disabled {
   font-family: var(--font-header);
 }
 
+.roster-card__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.roster-shuffle-btn {
+  padding: 4px 10px;
+  font-size: 0.75rem;
+}
+
 .roster-list {
   display: flex;
   flex-direction: column;

--- a/app/components/PlayerCardDrawer.tsx
+++ b/app/components/PlayerCardDrawer.tsx
@@ -156,8 +156,7 @@ const PlayerCardDrawer: React.FC<PlayerCardDrawerProps> = ({
           className={'drawCardsContainer'}
           style={{
             position: 'relative',
-            minHeight: '60px',
-            height: '60px',
+            minHeight: '70px',
             display: 'flex',
             justifyContent: 'center'
           }}

--- a/app/features/game/components/RosterSetup.tsx
+++ b/app/features/game/components/RosterSetup.tsx
@@ -20,6 +20,8 @@ type RosterSetupProps = SetupRosters & {
     toTeam: TeamName,
     toIndex: number
   ) => void;
+  onShuffleTeam: (team: TeamName) => void;
+  shuffleLabel: string;
 };
 
 const teamLabels: Record<TeamName, 'team1' | 'team2'> = {
@@ -36,7 +38,9 @@ export function RosterSetup({
   errors,
   onAddMember,
   onRemoveMember,
-  onMoveMember
+  onMoveMember,
+  onShuffleTeam,
+  shuffleLabel
 }: RosterSetupProps) {
   const [newMemberNames, setNewMemberNames] = useState<
     Record<TeamName, string>
@@ -68,7 +72,18 @@ export function RosterSetup({
     <section className={`roster-card roster-card--${teamLabels[team]}`}>
       <div className="roster-card__header">
         <h3>{title}</h3>
-        <span>{roster.length}</span>
+        <div className="roster-card__header-actions">
+          <span>{roster.length}</span>
+          <button
+            aria-label={`${shuffleLabel} ${title}`}
+            className="rpg-button secondary roster-shuffle-btn"
+            disabled={isLoading || roster.length < 2}
+            onClick={() => onShuffleTeam(team)}
+            type="button"
+          >
+            {shuffleLabel}
+          </button>
+        </div>
       </div>
 
       <ol

--- a/app/features/game/services/rosterSetup.ts
+++ b/app/features/game/services/rosterSetup.ts
@@ -44,6 +44,15 @@ export function removeRosterMember(roster: string[], index: number): string[] {
   return roster.filter((_, currentIndex) => currentIndex !== index);
 }
 
+export function shuffleRoster(roster: string[]): string[] {
+  const shuffled = [...roster];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
 export function moveRosterMember({
   team1,
   team2,

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -76,6 +76,7 @@ export default {
     rosterTeamEmpty: 'Each team must have at least one member.',
     rosterBlankName: 'Member names cannot be blank.',
     rosterDuplicateName: 'Member names must be unique across both teams.',
+    shuffleRoster: 'SHUFFLE',
     shareResult: 'SHARE RESULT',
     shareDownload: 'Download PNG',
     shareTweet: 'Tweet Result',

--- a/app/locales/vi.ts
+++ b/app/locales/vi.ts
@@ -75,6 +75,7 @@ export default {
     rosterTeamEmpty: 'Mỗi đội phải có ít nhất một thành viên.',
     rosterBlankName: 'Tên thành viên không được để trống.',
     rosterDuplicateName: 'Tên thành viên không được trùng giữa hai đội.',
+    shuffleRoster: 'XÁO TRỘN',
     shareResult: 'CHIA SẺ KẾT QUẢ',
     shareDownload: 'Tải PNG',
     shareTweet: 'Tweet Kết Quả',

--- a/app/routes/game.tsx
+++ b/app/routes/game.tsx
@@ -15,6 +15,7 @@ import {
   addRosterMember,
   moveRosterMember,
   removeRosterMember,
+  shuffleRoster,
   validateRosterSetup
 } from '~/features/game/services/rosterSetup';
 import {
@@ -1470,6 +1471,16 @@ const CardGame = () => {
     setSetupTeam2Roster(result.team2);
   };
 
+  const shuffleSetupRoster = (team: TeamName) => {
+    setRosterLoadError('');
+    if (team === 'team1') {
+      setSetupTeam1Roster((prev) => shuffleRoster(prev));
+      return;
+    }
+
+    setSetupTeam2Roster((prev) => shuffleRoster(prev));
+  };
+
   /**
    * Renders a label with a small preview icon positioned to the left of the text.
    * Used in the combined 'setup' screen for power-up labels.
@@ -2460,6 +2471,8 @@ const CardGame = () => {
                     onAddMember={addSetupRosterMember}
                     onRemoveMember={removeSetupRosterMember}
                     onMoveMember={moveSetupRosterMember}
+                    onShuffleTeam={shuffleSetupRoster}
+                    shuffleLabel={t('game.shuffleRoster')}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Add `shuffleRoster` helper using Fisher-Yates algorithm for unbiased shuffling.
- Add shuffle button to `RosterSetup` UI with disabled state when roster has fewer than 2 members.
- Wire shuffle handler into the game route's setup phase.
- Add locale strings for shuffle action (`SHUFFLE` / `XÁO TRỘN`).
- Add supporting CSS for shuffle button layout in roster card headers.
- Minor `PlayerCardDrawer` minHeight tweak (60px → 70px).

## Test Plan
- [ ] Verify `shuffleRoster` produces a valid permutation (Fisher-Yates).
- [ ] Verify shuffle button is disabled when a team has < 2 members.
- [ ] Verify shuffled roster order is reflected in the game setup.
- [ ] Run `npm run typecheck` — strict TypeScript, no errors.
- [ ] Run `npm run build` — production build succeeds.